### PR TITLE
Ignore file 'iredmail-release'

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -94,6 +94,7 @@ _DISTRO_RELEASE_IGNORE_BASENAMES = (
     _OS_RELEASE_BASENAME,
     'system-release',
     'plesk-release',
+    'iredmail-release',
 )
 
 


### PR DESCRIPTION
Ignore file `/etc/iredmail-release` while detecting target OS distribution, it may cause Ansible incorrectly identify target OS distro or release version.

File /etc/iredmail-release is generated by iRedMail - a popular open source mail server solution: https://www.iredmail.org/

- See also: https://github.com/ansible/ansible/pull/72538