### PR TITLE
Replace flake8 with pylint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python: 2.7
-            toxenv: pylint27
           - python: 3.8
             toxenv: pylint38
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         include:
           - python: 2.7
-            toxenv: flake8
+            toxenv: pylint27
           - python: 3.8
-            toxenv: py3flake8
+            toxenv: pylint38
 
     steps:
       - uses: actions/checkout@v2

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,554 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        invalid-unicode-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        locally-enabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape,
+        missing-docstring,
+        bad-continuation,
+        max-module-lines
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=optparse.Values,sys.exit
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=120
+
+# Maximum number of lines in a module
+max-module-lines=1500
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,io,builtins
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,StrigoCliError,Exception
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[BASIC]
+
+# Naming style matching correct argument names
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style
+#argument-rgx=
+
+# Naming style matching correct attribute names
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style
+#class-attribute-rgx=
+
+# Naming style matching correct class names
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-style
+#class-rgx=
+
+# Naming style matching correct constant names
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,
+           j,
+           k,
+           fh,
+           e,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style
+#inlinevar-rgx=
+
+# Naming style matching correct method names
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style
+#method-rgx=
+
+# Naming style matching correct module names
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style
+#variable-rgx=
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=10
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=10
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=20
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of locals for function / method body
+max-locals=20
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,
+                   TERMIOS,
+                   Bastion,
+                   rexec
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+pylint
 pytest
 pytest-cov
 sphinx>=1.1

--- a/distro.py
+++ b/distro.py
@@ -80,11 +80,11 @@ NORMALIZED_DISTRO_ID = {
 
 # Pattern for content of distro release file (reversed)
 _DISTRO_RELEASE_CONTENT_REVERSED_PATTERN = re.compile(
-    r'(?:[^)]*\)(.*)\()? *(?:STL )?([\d.+\-a-z]*\d) *(?:esaeler *)?(.+)')
+    r'(?:[^)]*\)(.*)\()? *(?:STL )?([\d.+\-a-z]*\d) *(?:esaeler *)?(.+)'
+)
 
 # Pattern for base file name of distro release file
-_DISTRO_RELEASE_BASENAME_PATTERN = re.compile(
-    r'(\w+)[-_](release|version)$')
+_DISTRO_RELEASE_BASENAME_PATTERN = re.compile(r'(\w+)[-_](release|version)$')
 
 # Base file names to be ignored when searching for distro release file
 _DISTRO_RELEASE_IGNORE_BASENAMES = (
@@ -122,10 +122,10 @@ def linux_distribution(full_distribution_name=True):
     method normalizes the distro ID string to a reliable machine-readable value
     for a number of popular OS distributions.
     """
-    return _distro.linux_distribution(full_distribution_name)
+    return _DISTRO.linux_distribution(full_distribution_name)
 
 
-def id():
+def id():  # pylint: disable=redefined-builtin, invalid-name
     """
     Return the distro ID of the current distribution, as a
     machine-readable string.
@@ -201,7 +201,7 @@ def id():
       command, with ID values that differ from what was previously determined
       from the distro release file name.
     """
-    return _distro.id()
+    return _DISTRO.id()
 
 
 def name(pretty=False):
@@ -240,7 +240,7 @@ def name(pretty=False):
         with the value of the pretty version ("<version_id>" and "<codename>"
         fields) of the distro release file, if available.
     """
-    return _distro.name(pretty)
+    return _DISTRO.name(pretty)
 
 
 def version(pretty=False, best=False):
@@ -284,7 +284,7 @@ def version(pretty=False, best=False):
       the lsb_release command, if it follows the format of the distro release
       files.
     """
-    return _distro.version(pretty, best)
+    return _DISTRO.version(pretty, best)
 
 
 def version_parts(best=False):
@@ -301,7 +301,7 @@ def version_parts(best=False):
     For a description of the *best* parameter, see the :func:`distro.version`
     method.
     """
-    return _distro.version_parts(best)
+    return _DISTRO.version_parts(best)
 
 
 def major_version(best=False):
@@ -314,7 +314,7 @@ def major_version(best=False):
     For a description of the *best* parameter, see the :func:`distro.version`
     method.
     """
-    return _distro.major_version(best)
+    return _DISTRO.major_version(best)
 
 
 def minor_version(best=False):
@@ -327,7 +327,7 @@ def minor_version(best=False):
     For a description of the *best* parameter, see the :func:`distro.version`
     method.
     """
-    return _distro.minor_version(best)
+    return _DISTRO.minor_version(best)
 
 
 def build_number(best=False):
@@ -340,7 +340,7 @@ def build_number(best=False):
     For a description of the *best* parameter, see the :func:`distro.version`
     method.
     """
-    return _distro.build_number(best)
+    return _DISTRO.build_number(best)
 
 
 def like():
@@ -357,7 +357,7 @@ def like():
     `os-release man page
     <http://www.freedesktop.org/software/systemd/man/os-release.html>`_.
     """
-    return _distro.like()
+    return _DISTRO.like()
 
 
 def codename():
@@ -381,7 +381,7 @@ def codename():
 
     * the value of the "<codename>" field of the distro release file.
     """
-    return _distro.codename()
+    return _DISTRO.codename()
 
 
 def info(pretty=False, best=False):
@@ -425,7 +425,7 @@ def info(pretty=False, best=False):
     For a description of the *pretty* and *best* parameters, see the
     :func:`distro.version` method.
     """
-    return _distro.info(pretty, best)
+    return _DISTRO.info(pretty, best)
 
 
 def os_release_info():
@@ -435,7 +435,7 @@ def os_release_info():
 
     See `os-release file`_ for details about these information items.
     """
-    return _distro.os_release_info()
+    return _DISTRO.os_release_info()
 
 
 def lsb_release_info():
@@ -446,7 +446,7 @@ def lsb_release_info():
     See `lsb_release command output`_ for details about these information
     items.
     """
-    return _distro.lsb_release_info()
+    return _DISTRO.lsb_release_info()
 
 
 def distro_release_info():
@@ -456,7 +456,7 @@ def distro_release_info():
 
     See `distro release file`_ for details about these information items.
     """
-    return _distro.distro_release_info()
+    return _DISTRO.distro_release_info()
 
 
 def uname_info():
@@ -464,7 +464,7 @@ def uname_info():
     Return a dictionary containing key-value pairs for the information items
     from the distro release file data source of the current OS distribution.
     """
-    return _distro.uname_info()
+    return _DISTRO.uname_info()
 
 
 def os_release_attr(attribute):
@@ -483,7 +483,7 @@ def os_release_attr(attribute):
 
     See `os-release file`_ for details about these information items.
     """
-    return _distro.os_release_attr(attribute)
+    return _DISTRO.os_release_attr(attribute)
 
 
 def lsb_release_attr(attribute):
@@ -503,7 +503,7 @@ def lsb_release_attr(attribute):
     See `lsb_release command output`_ for details about these information
     items.
     """
-    return _distro.lsb_release_attr(attribute)
+    return _DISTRO.lsb_release_attr(attribute)
 
 
 def distro_release_attr(attribute):
@@ -522,7 +522,7 @@ def distro_release_attr(attribute):
 
     See `distro release file`_ for details about these information items.
     """
-    return _distro.distro_release_attr(attribute)
+    return _DISTRO.distro_release_attr(attribute)
 
 
 def uname_attr(attribute):
@@ -539,14 +539,15 @@ def uname_attr(attribute):
     * (string): Value of the information item, if the item exists.
                 The empty string, if the item does not exist.
     """
-    return _distro.uname_attr(attribute)
+    return _DISTRO.uname_attr(attribute)
 
 
-class cached_property(object):
+class cached_property(object):  # pylint: disable=invalid-name, too-few-public-methods, useless-object-inheritance
     """A version of @property which caches the value.  On access, it calls the
     underlying function and sets the value in `__dict__` so future accesses
     will not re-call the property.
     """
+
     def __init__(self, f):
         self._fname = f.__name__
         self._f = f
@@ -557,7 +558,7 @@ class cached_property(object):
         return ret
 
 
-class LinuxDistribution(object):
+class LinuxDistribution:
     """
     Provides information about a OS distribution.
 
@@ -575,12 +576,7 @@ class LinuxDistribution(object):
     lsb_release command.
     """
 
-    def __init__(self,
-                 include_lsb=True,
-                 os_release_file='',
-                 distro_release_file='',
-                 include_uname=True,
-                 root_dir=None):
+    def __init__(self, include_lsb=True, os_release_file='', distro_release_file='', include_uname=True, root_dir=None):
         """
         The initialization method of this class gathers information from the
         available data sources, and stores that in private instance attributes.
@@ -652,28 +648,25 @@ class LinuxDistribution(object):
           uses an unexpected encoding.
         """
         self.root_dir = root_dir
-        self.etc_dir = os.path.join(root_dir, 'etc') \
-            if root_dir else _UNIXCONFDIR
-        self.os_release_file = os_release_file or \
-            os.path.join(self.etc_dir, _OS_RELEASE_BASENAME)
+        self.etc_dir = os.path.join(root_dir, 'etc') if root_dir else _UNIXCONFDIR
+        self.os_release_file = os_release_file or os.path.join(self.etc_dir, _OS_RELEASE_BASENAME)
         self.distro_release_file = distro_release_file or ''  # updated later
         self.include_lsb = include_lsb
         self.include_uname = include_uname
 
     def __repr__(self):
-        """Return repr of all info
-        """
-        return \
-            "LinuxDistribution(" \
-            "os_release_file={self.os_release_file!r}, " \
-            "distro_release_file={self.distro_release_file!r}, " \
-            "include_lsb={self.include_lsb!r}, " \
-            "include_uname={self.include_uname!r}, " \
-            "_os_release_info={self._os_release_info!r}, " \
-            "_lsb_release_info={self._lsb_release_info!r}, " \
-            "_distro_release_info={self._distro_release_info!r}, " \
-            "_uname_info={self._uname_info!r})".format(
-                self=self)
+        """Return repr of all info"""
+        return (
+            "LinuxDistribution("
+            "os_release_file={self.os_release_file!r}, "
+            "distro_release_file={self.distro_release_file!r}, "
+            "include_lsb={self.include_lsb!r}, "
+            "include_uname={self.include_uname!r}, "
+            "_os_release_info={self._os_release_info!r}, "
+            "_lsb_release_info={self._lsb_release_info!r}, "
+            "_distro_release_info={self._distro_release_info!r}, "
+            "_uname_info={self._uname_info!r})".format(self=self)
+        )
 
     def linux_distribution(self, full_distribution_name=True):
         """
@@ -683,17 +676,14 @@ class LinuxDistribution(object):
 
         For details, see :func:`distro.linux_distribution`.
         """
-        return (
-            self.name() if full_distribution_name else self.id(),
-            self.version(),
-            self.codename()
-        )
+        return (self.name() if full_distribution_name else self.id(), self.version(), self.codename())
 
-    def id(self):
+    def id(self):  # pylint: disable=redefined-builtin, invalid-name
         """Return the distro ID of the OS distribution, as a string.
 
         For details, see :func:`distro.id`.
         """
+
         def normalize(distro_id, table):
             distro_id = distro_id.lower().replace(' ', '_')
             return table.get(distro_id, distro_id)
@@ -722,17 +712,17 @@ class LinuxDistribution(object):
 
         For details, see :func:`distro.name`.
         """
-        name = self.os_release_attr('name') \
-            or self.lsb_release_attr('distributor_id') \
-            or self.distro_release_attr('name') \
+        name = (  # pylint: disable=redefined-outer-name
+            self.os_release_attr('name')
+            or self.lsb_release_attr('distributor_id')
+            or self.distro_release_attr('name')
             or self.uname_attr('name')
+        )
         if pretty:
-            name = self.os_release_attr('pretty_name') \
-                or self.lsb_release_attr('description')
+            name = self.os_release_attr('pretty_name') or self.lsb_release_attr('description')
             if not name:
-                name = self.distro_release_attr('name') \
-                       or self.uname_attr('name')
-                version = self.version(pretty=True)
+                name = self.distro_release_attr('name') or self.uname_attr('name')
+                version = self.version(pretty=True)  # pylint: disable=redefined-outer-name
                 if version:
                     name = name + ' ' + version
         return name or ''
@@ -747,25 +737,23 @@ class LinuxDistribution(object):
             self.os_release_attr('version_id'),
             self.lsb_release_attr('release'),
             self.distro_release_attr('version_id'),
-            self._parse_distro_release_content(
-                self.os_release_attr('pretty_name')).get('version_id', ''),
-            self._parse_distro_release_content(
-                self.lsb_release_attr('description')).get('version_id', ''),
-            self.uname_attr('release')
+            self._parse_distro_release_content(self.os_release_attr('pretty_name')).get('version_id', ''),
+            self._parse_distro_release_content(self.lsb_release_attr('description')).get('version_id', ''),
+            self.uname_attr('release'),
         ]
-        version = ''
+        version = ''  # pylint: disable=redefined-outer-name
         if best:
             # This algorithm uses the last version in priority order that has
             # the best precision. If the versions are not in conflict, that
             # does not matter; otherwise, using the last one instead of the
             # first one might be considered a surprise.
-            for v in versions:
-                if v.count(".") > version.count(".") or version == '':
-                    version = v
+            for version_option in versions:
+                if version_option.count(".") > version.count(".") or version == '':
+                    version = version_option
         else:
-            for v in versions:
-                if v != '':
-                    version = v
+            for version_option in versions:
+                if version_option != '':
+                    version = version_option
                     break
         if pretty and version and self.codename():
             version = '{0} ({1})'.format(version, self.codename())
@@ -783,7 +771,7 @@ class LinuxDistribution(object):
             version_regex = re.compile(r'(\d+)\.?(\d+)?\.?(\d+)?')
             matches = version_regex.match(version_str)
             if matches:
-                major, minor, build_number = matches.groups()
+                major, minor, build_number = matches.groups()  # pylint: disable=redefined-outer-name
                 return major, minor or '', build_number or ''
         return '', '', ''
 
@@ -803,7 +791,7 @@ class LinuxDistribution(object):
         """
         return self.version_parts(best)[1]
 
-    def build_number(self, best=False):
+    def build_number(self, best=False):  # pylint: disable=redefined-outer-name
         """
         Return the build number of the current distribution.
 
@@ -819,7 +807,7 @@ class LinuxDistribution(object):
         """
         return self.os_release_attr('id_like') or ''
 
-    def codename(self):
+    def codename(self):  # pylint: disable=redefined-outer-name
         """
         Return the codename of the OS distribution.
 
@@ -830,9 +818,7 @@ class LinuxDistribution(object):
             # this to empty string to have no codename
             return self._os_release_info['codename']
         except KeyError:
-            return self.lsb_release_attr('codename') \
-                or self.distro_release_attr('codename') \
-                or ''
+            return self.lsb_release_attr('codename') or self.distro_release_attr('codename') or ''
 
     def info(self, pretty=False, best=False):
         """
@@ -845,9 +831,7 @@ class LinuxDistribution(object):
             id=self.id(),
             version=self.version(pretty, best),
             version_parts=dict(
-                major=self.major_version(best),
-                minor=self.minor_version(best),
-                build_number=self.build_number(best)
+                major=self.major_version(best), minor=self.minor_version(best), build_number=self.build_number(best)
             ),
             like=self.like(),
             codename=self.codename(),
@@ -977,8 +961,8 @@ class LinuxDistribution(object):
             # * variable assignments: var=value
             # * commands or their arguments (not allowed in os-release)
             if '=' in token:
-                k, v = token.split('=', 1)
-                props[k.lower()] = v
+                key, value = token.split('=', 1)
+                props[key.lower()] = value
             else:
                 # Ignore any tokens that are not variable assignments
                 pass
@@ -994,7 +978,7 @@ class LinuxDistribution(object):
             props['codename'] = props['ubuntu_codename']
         elif 'version' in props:
             # If there is no version_codename, parse it from the version
-            codename = re.search(r'(\(\D+\))|,(\s+)?\D+', props['version'])
+            codename = re.search(r'(\(\D+\))|,(\s+)?\D+', props['version'])  # pylint: disable=redefined-outer-name
             if codename:
                 codename = codename.group()
                 codename = codename.strip('()')
@@ -1041,11 +1025,11 @@ class LinuxDistribution(object):
         """
         props = {}
         for line in lines:
-            kv = line.strip('\n').split(':', 1)
+            kv = line.strip('\n').split(':', 1)  # pylint: disable=invalid-name
             if len(kv) != 2:
                 # Ignore lines without colon.
                 continue
-            k, v = kv
+            k, v = kv  # pylint: disable=invalid-name
             props.update({k.replace(' ', '_').lower(): v.strip()})
         return props
 
@@ -1065,7 +1049,7 @@ class LinuxDistribution(object):
         props = {}
         match = re.search(r'^([^\s]+)\s+([\d\.]+)', lines[0].strip())
         if match:
-            name, version = match.groups()
+            name, version = match.groups()  # pylint: disable=redefined-outer-name
 
             # This is to prevent the Linux kernel version from
             # appearing as the 'best' version on otherwise
@@ -1086,7 +1070,7 @@ class LinuxDistribution(object):
             if isinstance(text, bytes):
                 return text.decode(encoding)
         else:
-            if isinstance(text, unicode):  # noqa
+            if isinstance(text, unicode):  # pylint: disable=undefined-variable
                 return text.encode(encoding)
 
         return text
@@ -1102,62 +1086,62 @@ class LinuxDistribution(object):
         if self.distro_release_file:
             # If it was specified, we use it and parse what we can, even if
             # its file name or content does not match the expected pattern.
-            distro_info = self._parse_distro_release_file(
-                self.distro_release_file)
+            distro_info = self._parse_distro_release_file(self.distro_release_file)
             basename = os.path.basename(self.distro_release_file)
             # The file name pattern for user-specified distro release files
             # is somewhat more tolerant (compared to when searching for the
             # file), because we want to use what was specified as best as
             # possible.
             match = _DISTRO_RELEASE_BASENAME_PATTERN.match(basename)
-            if 'name' in distro_info \
-               and 'cloudlinux' in distro_info['name'].lower():
+            if 'name' in distro_info and 'cloudlinux' in distro_info['name'].lower():
                 distro_info['id'] = 'cloudlinux'
             elif match:
                 distro_info['id'] = match.group(1)
             return distro_info
-        else:
-            try:
-                basenames = os.listdir(self.etc_dir)
-                # We sort for repeatability in cases where there are multiple
-                # distro specific files; e.g. CentOS, Oracle, Enterprise all
-                # containing `redhat-release` on top of their own.
-                basenames.sort()
-            except OSError:
-                # This may occur when /etc is not readable but we can't be
-                # sure about the *-release files. Check common entries of
-                # /etc for information. If they turn out to not be there the
-                # error is handled in `_parse_distro_release_file()`.
-                basenames = ['SuSE-release',
-                             'arch-release',
-                             'base-release',
-                             'centos-release',
-                             'fedora-release',
-                             'gentoo-release',
-                             'mageia-release',
-                             'mandrake-release',
-                             'mandriva-release',
-                             'mandrivalinux-release',
-                             'manjaro-release',
-                             'oracle-release',
-                             'redhat-release',
-                             'sl-release',
-                             'slackware-version']
-            for basename in basenames:
-                if basename in _DISTRO_RELEASE_IGNORE_BASENAMES:
-                    continue
-                match = _DISTRO_RELEASE_BASENAME_PATTERN.match(basename)
-                if match:
-                    filepath = os.path.join(self.etc_dir, basename)
-                    distro_info = self._parse_distro_release_file(filepath)
-                    if 'name' in distro_info:
-                        # The name is always present if the pattern matches
-                        self.distro_release_file = filepath
-                        distro_info['id'] = match.group(1)
-                        if 'cloudlinux' in distro_info['name'].lower():
-                            distro_info['id'] = 'cloudlinux'
-                        return distro_info
-            return {}
+
+        try:
+            basenames = os.listdir(self.etc_dir)
+            # We sort for repeatability in cases where there are multiple
+            # distro specific files; e.g. CentOS, Oracle, Enterprise all
+            # containing `redhat-release` on top of their own.
+            basenames.sort()
+        except OSError:
+            # This may occur when /etc is not readable but we can't be
+            # sure about the *-release files. Check common entries of
+            # /etc for information. If they turn out to not be there the
+            # error is handled in `_parse_distro_release_file()`.
+            basenames = [
+                'SuSE-release',
+                'arch-release',
+                'base-release',
+                'centos-release',
+                'fedora-release',
+                'gentoo-release',
+                'mageia-release',
+                'mandrake-release',
+                'mandriva-release',
+                'mandrivalinux-release',
+                'manjaro-release',
+                'oracle-release',
+                'redhat-release',
+                'sl-release',
+                'slackware-version',
+            ]
+        for basename in basenames:
+            if basename in _DISTRO_RELEASE_IGNORE_BASENAMES:
+                continue
+            match = _DISTRO_RELEASE_BASENAME_PATTERN.match(basename)
+            if match:
+                filepath = os.path.join(self.etc_dir, basename)
+                distro_info = self._parse_distro_release_file(filepath)
+                if 'name' in distro_info:
+                    # The name is always present if the pattern matches
+                    self.distro_release_file = filepath
+                    distro_info['id'] = match.group(1)
+                    if 'cloudlinux' in distro_info['name'].lower():
+                        distro_info['id'] = 'cloudlinux'
+                    return distro_info
+        return {}
 
     def _parse_distro_release_file(self, filepath):
         """
@@ -1171,10 +1155,10 @@ class LinuxDistribution(object):
             A dictionary containing all information items.
         """
         try:
-            with open(filepath) as fp:
+            with open(filepath) as file_to_open:
                 # Only parse the first line. For instance, on SLES there
                 # are multiple lines. We don't want them...
-                return self._parse_distro_release_content(fp.readline())
+                return self._parse_distro_release_content(file_to_open.readline())
         except (OSError, IOError):
             # Ignore not being able to read a specific, seemingly version
             # related file.
@@ -1193,8 +1177,7 @@ class LinuxDistribution(object):
         Returns:
             A dictionary containing all information items.
         """
-        matches = _DISTRO_RELEASE_CONTENT_REVERSED_PATTERN.match(
-            line.strip()[::-1])
+        matches = _DISTRO_RELEASE_CONTENT_REVERSED_PATTERN.match(line.strip()[::-1])
         distro_info = {}
         if matches:
             # regexp ensures non-None
@@ -1208,7 +1191,7 @@ class LinuxDistribution(object):
         return distro_info
 
 
-_distro = LinuxDistribution()
+_DISTRO = LinuxDistribution()
 
 
 def main():
@@ -1217,28 +1200,18 @@ def main():
     logger.addHandler(logging.StreamHandler(sys.stdout))
 
     parser = argparse.ArgumentParser(description="OS distro info tool")
-    parser.add_argument(
-        '--json',
-        '-j',
-        help="Output in machine readable format",
-        action="store_true")
+    parser.add_argument('--json', '-j', help="Output in machine readable format", action="store_true")
 
     parser.add_argument(
-        '--root-dir',
-        '-r',
-        type=str,
-        dest='root_dir',
-        help="Path to the root filesystem directory (defaults to /)")
+        '--root-dir', '-r', type=str, dest='root_dir', help="Path to the root filesystem directory (defaults to /)"
+    )
 
     args = parser.parse_args()
 
     if args.root_dir:
-        dist = LinuxDistribution(
-            include_lsb=False,
-            include_uname=False,
-            root_dir=args.root_dir)
+        dist = LinuxDistribution(include_lsb=False, include_uname=False, root_dir=args.root_dir)
     else:
-        dist = _distro
+        dist = _DISTRO
 
     if args.json:
         logger.info(json.dumps(dist.info(), indent=4, sort_keys=True))

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -17,6 +17,7 @@ import os
 import sys
 import ast
 import subprocess
+
 try:
     from StringIO import StringIO  # Python 2.x
 except ImportError:
@@ -26,19 +27,19 @@ import pytest
 
 
 BASE = os.path.abspath(os.path.dirname(__file__))
-RESOURCES = os.path.join(BASE, 'resources')
-DISTROS_DIR = os.path.join(RESOURCES, 'distros')
-TESTDISTROS = os.path.join(RESOURCES, 'testdistros')
-SPECIAL = os.path.join(RESOURCES, 'special')
-DISTROS = [dist for dist in os.listdir(DISTROS_DIR) if dist != '__shared__']
+RESOURCES = os.path.join(BASE, "resources")
+DISTROS_DIR = os.path.join(RESOURCES, "distros")
+TESTDISTROS = os.path.join(RESOURCES, "testdistros")
+SPECIAL = os.path.join(RESOURCES, "special")
+DISTROS = [dist for dist in os.listdir(DISTROS_DIR) if dist != "__shared__"]
 
 
-IS_LINUX = sys.platform.startswith('linux')
+IS_LINUX = sys.platform.startswith("linux")
 if IS_LINUX:
     import distro
 
     RELATIVE_UNIXCONFDIR = distro._UNIXCONFDIR[1:]
-    MODULE_DISTRO = distro._distro
+    MODULE_DISTRO = distro._DISTRO
 
 
 class TestNonLinuxPlatform:
@@ -46,73 +47,72 @@ class TestNonLinuxPlatform:
         try:
             import distro  # NOQA
         except ImportError as ex:
-            assert 'Unsupported platform' in str(ex)
+            assert "Unsupported platform" in str(ex)
 
 
-@pytest.mark.skipif(not IS_LINUX, reason='Irrelevant on non-linux')
+@pytest.mark.skipif(not IS_LINUX, reason="Irrelevant on non-linux")
 class TestCli:
-
     def _parse(self, command):
         sys.argv = command.split()
         distro.main()
 
     def _run(self, command):
         stdout, _ = subprocess.Popen(
-            command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE).communicate()
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        ).communicate()
         # Need to decode or we get bytes in Python 3.x
-        return stdout.decode('utf-8')
+        return stdout.decode("utf-8")
 
     def test_cli_for_coverage_yuch(self):
-        self._parse('distro')
-        self._parse('distro -j')
+        self._parse("distro")
+        self._parse("distro -j")
 
     def test_cli_can_parse_root_dir_args(self):
-        root_dir = os.path.join(RESOURCES, 'cli', 'fedora30')
-        self._parse('distro --root-dir {}'.format(root_dir))
+        root_dir = os.path.join(RESOURCES, "cli", "fedora30")
+        self._parse("distro --root-dir {}".format(root_dir))
 
     def test_cli(self):
-        command = [sys.executable, '-m', 'distro']
-        desired_output = 'Name: ' + distro.name(pretty=True)
+        command = [sys.executable, "-m", "distro"]
+        desired_output = "Name: " + distro.name(pretty=True)
         distro_version = distro.version(pretty=True)
         distro_codename = distro.codename()
-        desired_output += '\n' + 'Version: ' + distro_version
-        desired_output += '\n' + 'Codename: ' + distro_codename
-        desired_output += '\n'
+        desired_output += "\n" + "Version: " + distro_version
+        desired_output += "\n" + "Codename: " + distro_codename
+        desired_output += "\n"
         assert self._run(command) == desired_output
 
     def test_cli_json(self):
-        command = [sys.executable, '-m', 'distro', '-j']
+        command = [sys.executable, "-m", "distro", "-j"]
         assert ast.literal_eval(self._run(command)) == distro.info()
 
     def test_cli_with_root_dir(self):
-        root_dir = os.path.join(RESOURCES, 'cli', 'fedora30')
-        command = [sys.executable, '-m', 'distro', '--root-dir', root_dir]
-        desired_output = 'Name: Fedora 30 (Thirty)\nVersion: 30\nCodename: \n'
+        root_dir = os.path.join(RESOURCES, "cli", "fedora30")
+        command = [sys.executable, "-m", "distro", "--root-dir", root_dir]
+        desired_output = "Name: Fedora 30 (Thirty)\nVersion: 30\nCodename: \n"
         assert desired_output == self._run(command)
 
     def test_cli_with_root_dir_as_json(self):
         import json
-        root_dir = os.path.join(RESOURCES, 'cli', 'fedora30')
-        command = [sys.executable, '-m', 'distro', '-j', '--root-dir', root_dir]
+
+        root_dir = os.path.join(RESOURCES, "cli", "fedora30")
+        command = [sys.executable, "-m", "distro", "-j", "--root-dir", root_dir]
         desired_output = {
-            'codename': '',
-            'id': 'fedora',
-            'like': '',
-            'version': '30',
-            'version_parts': {
-                'build_number': '',
-                'major': '30',
-                'minor': '',
-            }
+            "codename": "",
+            "id": "fedora",
+            "like": "",
+            "version": "30",
+            "version_parts": {
+                "build_number": "",
+                "major": "30",
+                "minor": "",
+            },
         }
 
         results = json.loads(self._run(command))
         assert desired_output == results
 
 
-@pytest.mark.skipif(not IS_LINUX, reason='Irrelevant on non-linux')
+@pytest.mark.skipif(not IS_LINUX, reason="Irrelevant on non-linux")
 class DistroTestCase(object):
     """A base class for any testcase classes that test the distributions
     represented in the `DISTROS` subtree.
@@ -130,113 +130,111 @@ class DistroTestCase(object):
         distro._UNIXCONFDIR = self._saved_UNIXCONFDIR
 
     def _setup_for_distro(self, distro_root):
-        distro_bin = os.path.join(distro_root, 'bin')
+        distro_bin = os.path.join(distro_root, "bin")
         # We don't want to pick up a possibly present lsb_release in the
         # distro that runs this test, so we use a PATH with only one entry:
         os.environ["PATH"] = distro_bin
         distro._UNIXCONFDIR = os.path.join(distro_root, RELATIVE_UNIXCONFDIR)
 
 
-@pytest.mark.skipif(not IS_LINUX, reason='Irrelevant on non-linux')
+@pytest.mark.skipif(not IS_LINUX, reason="Irrelevant on non-linux")
 class TestOSRelease:
-
     def setup_method(self, test_method):
-        dist = test_method.__name__.split('_')[1]
-        os_release = os.path.join(DISTROS_DIR, dist, 'etc', 'os-release')
+        dist = test_method.__name__.split("_")[1]
+        os_release = os.path.join(DISTROS_DIR, dist, "etc", "os-release")
         self.distro = distro.LinuxDistribution(
             include_lsb=False,
             os_release_file=os_release,
-            distro_release_file='path-to-non-existing-file')
+            distro_release_file="path-to-non-existing-file",
+        )
 
     def _test_outcome(self, outcome):
-        assert self.distro.id() == outcome.get('id', '')
-        assert self.distro.name() == outcome.get('name', '')
-        assert self.distro.name(pretty=True) == outcome.get('pretty_name', '')
-        assert self.distro.version() == outcome.get('version', '')
-        assert self.distro.version(pretty=True) == \
-            outcome.get('pretty_version', '')
-        assert self.distro.version(best=True) == \
-            outcome.get('best_version', '')
-        assert self.distro.like() == outcome.get('like', '')
-        assert self.distro.codename() == outcome.get('codename', '')
+        assert self.distro.id() == outcome.get("id", "")
+        assert self.distro.name() == outcome.get("name", "")
+        assert self.distro.name(pretty=True) == outcome.get("pretty_name", "")
+        assert self.distro.version() == outcome.get("version", "")
+        assert self.distro.version(pretty=True) == outcome.get("pretty_version", "")
+        assert self.distro.version(best=True) == outcome.get("best_version", "")
+        assert self.distro.like() == outcome.get("like", "")
+        assert self.distro.codename() == outcome.get("codename", "")
 
     def test_arch_os_release(self):
         desired_outcome = {
-            'id': 'arch',
-            'name': 'Arch Linux',
-            'pretty_name': 'Arch Linux',
+            "id": "arch",
+            "name": "Arch Linux",
+            "pretty_name": "Arch Linux",
         }
         self._test_outcome(desired_outcome)
 
     def test_kali_os_release(self):
         desired_outcome = {
-            'id': 'kali',
-            'name': 'Kali GNU/Linux',
-            'pretty_name': 'Kali GNU/Linux Rolling',
-            'version': '2017.1',
-            'pretty_version': '2017.1',
-            'best_version': '2017.1',
-            'like': 'debian'
+            "id": "kali",
+            "name": "Kali GNU/Linux",
+            "pretty_name": "Kali GNU/Linux Rolling",
+            "version": "2017.1",
+            "pretty_version": "2017.1",
+            "best_version": "2017.1",
+            "like": "debian",
         }
         self._test_outcome(desired_outcome)
 
     def test_centos7_os_release(self):
         desired_outcome = {
-            'id': 'centos',
-            'name': 'CentOS Linux',
-            'pretty_name': 'CentOS Linux 7 (Core)',
-            'version': '7',
-            'pretty_version': '7 (Core)',
-            'best_version': '7',
-            'like': 'rhel fedora',
-            'codename': 'Core'
+            "id": "centos",
+            "name": "CentOS Linux",
+            "pretty_name": "CentOS Linux 7 (Core)",
+            "version": "7",
+            "pretty_version": "7 (Core)",
+            "best_version": "7",
+            "like": "rhel fedora",
+            "codename": "Core",
         }
         self._test_outcome(desired_outcome)
 
     def test_coreos_os_release(self):
         desired_outcome = {
-            'id': 'coreos',
-            'name': 'CoreOS',
-            'pretty_name': 'CoreOS 899.15.0',
-            'version': '899.15.0',
-            'pretty_version': '899.15.0',
-            'best_version': '899.15.0'
+            "id": "coreos",
+            "name": "CoreOS",
+            "pretty_name": "CoreOS 899.15.0",
+            "version": "899.15.0",
+            "pretty_version": "899.15.0",
+            "best_version": "899.15.0",
         }
         self._test_outcome(desired_outcome)
 
     def test_debian8_os_release(self):
         desired_outcome = {
-            'id': 'debian',
-            'name': 'Debian GNU/Linux',
-            'pretty_name': 'Debian GNU/Linux 8 (jessie)',
-            'version': '8',
-            'pretty_version': '8 (jessie)',
-            'best_version': '8',
-            'codename': 'jessie'
+            "id": "debian",
+            "name": "Debian GNU/Linux",
+            "pretty_name": "Debian GNU/Linux 8 (jessie)",
+            "version": "8",
+            "pretty_version": "8 (jessie)",
+            "best_version": "8",
+            "codename": "jessie",
         }
         self._test_outcome(desired_outcome)
 
     def test_fedora19_os_release(self):
         desired_outcome = {
-            'id': 'fedora',
-            'name': 'Fedora',
-            'pretty_name': 'Fedora 19 (Schrödinger’s Cat)',
-            'version': '19',
-            'pretty_version': '19 (Schrödinger’s Cat)',
-            'best_version': '19',
-            'codename': 'Schrödinger’s Cat'
+            "id": "fedora",
+            "name": "Fedora",
+            "pretty_name": "Fedora 19 (Schrödinger’s Cat)",
+            "version": "19",
+            "pretty_version": "19 (Schrödinger’s Cat)",
+            "best_version": "19",
+            "codename": "Schrödinger’s Cat",
         }
         self._test_outcome(desired_outcome)
 
     def test_fedora23_os_release(self):
         desired_outcome = {
-            'id': 'fedora',
-            'name': 'Fedora',
-            'pretty_name': 'Fedora 23 (Twenty Three)',
-            'version': '23',
-            'pretty_version': '23 (Twenty Three)',
-            'best_version': '23',
-            'codename': 'Twenty Three'
+            "id": "fedora",
+            "name": "Fedora",
+            "pretty_name": "Fedora 23 (Twenty Three)",
+            "version": "23",
+            "pretty_version": "23 (Twenty Three)",
+            "best_version": "23",
+            "codename": "Twenty Three",
         }
         self._test_outcome(desired_outcome)
 
@@ -245,26 +243,26 @@ class TestOSRelease:
         # changed in a detectable way in Fedora 30+.  The piece in parenthesis in the pretty_name
         # field contains the VARIANT and differs depending on the variant which was installed.
         desired_outcome = {
-            'id': 'fedora',
-            'name': 'Fedora',
-            'pretty_name': 'Fedora 30 (Thirty)',
-            'version': '30',
-            'pretty_version': '30',
-            'best_version': '30',
-            'codename': ''
+            "id": "fedora",
+            "name": "Fedora",
+            "pretty_name": "Fedora 30 (Thirty)",
+            "version": "30",
+            "pretty_version": "30",
+            "best_version": "30",
+            "codename": "",
         }
         self._test_outcome(desired_outcome)
 
     def test_kvmibm1_os_release(self):
         desired_outcome = {
-            'id': 'kvmibm',
-            'name': 'KVM for IBM z Systems',
-            'pretty_name': 'KVM for IBM z Systems 1.1.1 (Z)',
-            'version': '1.1.1',
-            'pretty_version': '1.1.1 (Z)',
-            'best_version': '1.1.1',
-            'like': 'rhel fedora',
-            'codename': 'Z'
+            "id": "kvmibm",
+            "name": "KVM for IBM z Systems",
+            "pretty_name": "KVM for IBM z Systems 1.1.1 (Z)",
+            "version": "1.1.1",
+            "pretty_version": "1.1.1 (Z)",
+            "best_version": "1.1.1",
+            "like": "rhel fedora",
+            "codename": "Z",
         }
         self._test_outcome(desired_outcome)
 
@@ -272,191 +270,193 @@ class TestOSRelease:
         # Note: LinuxMint 17 actually *does* have Ubuntu 14.04 data in its
         #       os-release file. See discussion in GitHub issue #78.
         desired_outcome = {
-            'id': 'ubuntu',
-            'name': 'Ubuntu',
-            'pretty_name': 'Ubuntu 14.04.3 LTS',
-            'version': '14.04',
-            'pretty_version': '14.04 (Trusty Tahr)',
-            'best_version': '14.04.3',
-            'like': 'debian',
-            'codename': 'Trusty Tahr'
+            "id": "ubuntu",
+            "name": "Ubuntu",
+            "pretty_name": "Ubuntu 14.04.3 LTS",
+            "version": "14.04",
+            "pretty_version": "14.04 (Trusty Tahr)",
+            "best_version": "14.04.3",
+            "like": "debian",
+            "codename": "Trusty Tahr",
         }
         self._test_outcome(desired_outcome)
 
     def test_mageia5_os_release(self):
         desired_outcome = {
-            'id': 'mageia',
-            'name': 'Mageia',
-            'pretty_name': 'Mageia 5',
-            'version': '5',
-            'pretty_version': '5',
-            'best_version': '5',
-            'like': 'mandriva fedora',
+            "id": "mageia",
+            "name": "Mageia",
+            "pretty_name": "Mageia 5",
+            "version": "5",
+            "pretty_version": "5",
+            "best_version": "5",
+            "like": "mandriva fedora",
         }
         self._test_outcome(desired_outcome)
 
     def test_manjaro1512_os_release(self):
-        self._test_outcome({
-            'id': 'manjaro',
-            'name': 'Manjaro Linux',
-            'pretty_name': 'Manjaro Linux',
-        })
+        self._test_outcome(
+            {
+                "id": "manjaro",
+                "name": "Manjaro Linux",
+                "pretty_name": "Manjaro Linux",
+            }
+        )
 
     def test_opensuse42_os_release(self):
         desired_outcome = {
-            'id': 'opensuse',
-            'name': 'openSUSE Leap',
-            'pretty_name': 'openSUSE Leap 42.1 (x86_64)',
-            'version': '42.1',
-            'pretty_version': '42.1',
-            'best_version': '42.1',
-            'like': 'suse',
+            "id": "opensuse",
+            "name": "openSUSE Leap",
+            "pretty_name": "openSUSE Leap 42.1 (x86_64)",
+            "version": "42.1",
+            "pretty_version": "42.1",
+            "best_version": "42.1",
+            "like": "suse",
         }
         self._test_outcome(desired_outcome)
 
     def test_raspbian7_os_release(self):
         desired_outcome = {
-            'id': 'raspbian',
-            'name': 'Raspbian GNU/Linux',
-            'pretty_name': 'Raspbian GNU/Linux 7 (wheezy)',
-            'version': '7',
-            'pretty_version': '7 (wheezy)',
-            'best_version': '7',
-            'like': 'debian',
-            'codename': 'wheezy'
+            "id": "raspbian",
+            "name": "Raspbian GNU/Linux",
+            "pretty_name": "Raspbian GNU/Linux 7 (wheezy)",
+            "version": "7",
+            "pretty_version": "7 (wheezy)",
+            "best_version": "7",
+            "like": "debian",
+            "codename": "wheezy",
         }
         self._test_outcome(desired_outcome)
 
     def test_raspbian8_os_release(self):
         desired_outcome = {
-            'id': 'raspbian',
-            'name': 'Raspbian GNU/Linux',
-            'pretty_name': 'Raspbian GNU/Linux 8 (jessie)',
-            'version': '8',
-            'pretty_version': '8 (jessie)',
-            'best_version': '8',
-            'like': 'debian',
-            'codename': 'jessie'
+            "id": "raspbian",
+            "name": "Raspbian GNU/Linux",
+            "pretty_name": "Raspbian GNU/Linux 8 (jessie)",
+            "version": "8",
+            "pretty_version": "8 (jessie)",
+            "best_version": "8",
+            "like": "debian",
+            "codename": "jessie",
         }
         self._test_outcome(desired_outcome)
 
     def test_rhel7_os_release(self):
         desired_outcome = {
-            'id': 'rhel',
-            'name': 'Red Hat Enterprise Linux Server',
-            'pretty_name': 'Red Hat Enterprise Linux Server 7.0 (Maipo)',
-            'version': '7.0',
-            'pretty_version': '7.0 (Maipo)',
-            'best_version': '7.0',
-            'like': 'fedora',
-            'codename': 'Maipo'
+            "id": "rhel",
+            "name": "Red Hat Enterprise Linux Server",
+            "pretty_name": "Red Hat Enterprise Linux Server 7.0 (Maipo)",
+            "version": "7.0",
+            "pretty_version": "7.0 (Maipo)",
+            "best_version": "7.0",
+            "like": "fedora",
+            "codename": "Maipo",
         }
         self._test_outcome(desired_outcome)
 
     def test_slackware14_os_release(self):
         desired_outcome = {
-            'id': 'slackware',
-            'name': 'Slackware',
-            'pretty_name': 'Slackware 14.1',
-            'version': '14.1',
-            'pretty_version': '14.1',
-            'best_version': '14.1'
+            "id": "slackware",
+            "name": "Slackware",
+            "pretty_name": "Slackware 14.1",
+            "version": "14.1",
+            "pretty_version": "14.1",
+            "best_version": "14.1",
         }
         self._test_outcome(desired_outcome)
 
     def test_sles12_os_release(self):
         desired_outcome = {
-            'id': 'sles',
-            'name': 'SLES',
-            'pretty_name': 'SUSE Linux Enterprise Server 12 SP1',
-            'version': '12.1',
-            'pretty_version': '12.1',
-            'best_version': '12.1'
+            "id": "sles",
+            "name": "SLES",
+            "pretty_name": "SUSE Linux Enterprise Server 12 SP1",
+            "version": "12.1",
+            "pretty_version": "12.1",
+            "best_version": "12.1",
         }
         self._test_outcome(desired_outcome)
 
     def test_ubuntu14_os_release(self):
         desired_outcome = {
-            'id': 'ubuntu',
-            'name': 'Ubuntu',
-            'pretty_name': 'Ubuntu 14.04.3 LTS',
-            'version': '14.04',
-            'pretty_version': '14.04 (Trusty Tahr)',
-            'best_version': '14.04.3',
-            'like': 'debian',
-            'codename': 'Trusty Tahr'
+            "id": "ubuntu",
+            "name": "Ubuntu",
+            "pretty_name": "Ubuntu 14.04.3 LTS",
+            "version": "14.04",
+            "pretty_version": "14.04 (Trusty Tahr)",
+            "best_version": "14.04.3",
+            "like": "debian",
+            "codename": "Trusty Tahr",
         }
         self._test_outcome(desired_outcome)
 
     def test_ubuntu16_os_release(self):
         desired_outcome = {
-            'id': 'ubuntu',
-            'name': 'Ubuntu',
-            'pretty_name': 'Ubuntu 16.04.1 LTS',
-            'version': '16.04',
-            'pretty_version': '16.04 (xenial)',
-            'best_version': '16.04.1',
-            'like': 'debian',
-            'codename': 'xenial'
+            "id": "ubuntu",
+            "name": "Ubuntu",
+            "pretty_name": "Ubuntu 16.04.1 LTS",
+            "version": "16.04",
+            "pretty_version": "16.04 (xenial)",
+            "best_version": "16.04.1",
+            "like": "debian",
+            "codename": "xenial",
         }
         self._test_outcome(desired_outcome)
 
     def test_amazon2016_os_release(self):
         desired_outcome = {
-            'id': 'amzn',
-            'name': 'Amazon Linux AMI',
-            'pretty_name': 'Amazon Linux AMI 2016.03',
-            'version': '2016.03',
-            'pretty_version': '2016.03',
-            'best_version': '2016.03',
-            'like': 'rhel fedora'
+            "id": "amzn",
+            "name": "Amazon Linux AMI",
+            "pretty_name": "Amazon Linux AMI 2016.03",
+            "version": "2016.03",
+            "pretty_version": "2016.03",
+            "best_version": "2016.03",
+            "like": "rhel fedora",
         }
         self._test_outcome(desired_outcome)
 
     def test_scientific7_os_release(self):
         desired_outcome = {
-            'id': 'rhel',
-            'name': 'Scientific Linux',
-            'pretty_name': 'Scientific Linux 7.2 (Nitrogen)',
-            'version': '7.2',
-            'pretty_version': '7.2 (Nitrogen)',
-            'best_version': '7.2',
-            'like': 'fedora',
-            'codename': 'Nitrogen'
+            "id": "rhel",
+            "name": "Scientific Linux",
+            "pretty_name": "Scientific Linux 7.2 (Nitrogen)",
+            "version": "7.2",
+            "pretty_version": "7.2 (Nitrogen)",
+            "best_version": "7.2",
+            "like": "fedora",
+            "codename": "Nitrogen",
         }
         self._test_outcome(desired_outcome)
 
     def test_gentoo_os_release(self):
         desired_outcome = {
-            'id': 'gentoo',
-            'name': 'Gentoo',
-            'pretty_name': 'Gentoo/Linux',
+            "id": "gentoo",
+            "name": "Gentoo",
+            "pretty_name": "Gentoo/Linux",
         }
         self._test_outcome(desired_outcome)
 
     def test_openelec6_os_release(self):
         desired_outcome = {
-            'id': 'openelec',
-            'name': 'OpenELEC',
-            'pretty_name': 'OpenELEC (official) - Version: 6.0.3',
-            'version': '6.0',
-            'pretty_version': '6.0',
-            'best_version': '6.0.3',
+            "id": "openelec",
+            "name": "OpenELEC",
+            "pretty_name": "OpenELEC (official) - Version: 6.0.3",
+            "version": "6.0",
+            "pretty_version": "6.0",
+            "best_version": "6.0.3",
         }
         self._test_outcome(desired_outcome)
 
     def test_cloudlinux7_os_release(self):
         desired_outcome = {
-            'id': 'cloudlinux',
-            'codename': 'Yury Malyshev',
-            'name': 'CloudLinux',
-            'pretty_name': 'CloudLinux 7.3 (Yury Malyshev)',
-            'like': 'rhel fedora centos',
-            'version': '7.3',
-            'pretty_version': '7.3 (Yury Malyshev)',
-            'best_version': '7.3',
-            'major_version': '7',
-            'minor_version': '3'
+            "id": "cloudlinux",
+            "codename": "Yury Malyshev",
+            "name": "CloudLinux",
+            "pretty_name": "CloudLinux 7.3 (Yury Malyshev)",
+            "like": "rhel fedora centos",
+            "version": "7.3",
+            "pretty_version": "7.3 (Yury Malyshev)",
+            "best_version": "7.3",
+            "major_version": "7",
+            "minor_version": "3",
         }
         self._test_outcome(desired_outcome)
 
@@ -467,62 +467,63 @@ class TestWithRootDir(TestOSRelease):
     """
 
     def setup_method(self, test_method):
-        dist = test_method.__name__.split('_')[1]
+        dist = test_method.__name__.split("_")[1]
         root_dir = os.path.join(DISTROS_DIR, dist)
         self.distro = distro.LinuxDistribution(
             include_lsb=False,
-            os_release_file='',
-            distro_release_file='path-to-non-existing-file',
+            os_release_file="",
+            distro_release_file="path-to-non-existing-file",
             include_uname=False,
-            root_dir=root_dir)
+            root_dir=root_dir,
+        )
 
 
-@pytest.mark.skipif(not IS_LINUX, reason='Irrelevant on non-linux')
+@pytest.mark.skipif(not IS_LINUX, reason="Irrelevant on non-linux")
 class TestLSBRelease(DistroTestCase):
-
     def setup_method(self, test_method):
         super(TestLSBRelease, self).setup_method(test_method)
-        dist = test_method.__name__.split('_')[1]
+        dist = test_method.__name__.split("_")[1]
         self._setup_for_distro(os.path.join(DISTROS_DIR, dist))
         self.distro = distro.LinuxDistribution(
             include_lsb=True,
-            os_release_file='path-to-non-existing-file',
-            distro_release_file='path-to-non-existing-file')
+            os_release_file="path-to-non-existing-file",
+            distro_release_file="path-to-non-existing-file",
+        )
 
     def _test_outcome(self, outcome):
-        assert self.distro.id() == outcome.get('id', '')
-        assert self.distro.name() == outcome.get('name', '')
-        assert self.distro.name(pretty=True) == outcome.get('pretty_name', '')
-        assert self.distro.version() == outcome.get('version', '')
-        assert self.distro.version(pretty=True) == \
-            outcome.get('pretty_version', '')
-        assert self.distro.version(best=True) == \
-            outcome.get('best_version', '')
-        assert self.distro.like() == outcome.get('like', '')
-        assert self.distro.codename() == outcome.get('codename', '')
+        assert self.distro.id() == outcome.get("id", "")
+        assert self.distro.name() == outcome.get("name", "")
+        assert self.distro.name(pretty=True) == outcome.get("pretty_name", "")
+        assert self.distro.version() == outcome.get("version", "")
+        assert self.distro.version(pretty=True) == outcome.get("pretty_version", "")
+        assert self.distro.version(best=True) == outcome.get("best_version", "")
+        assert self.distro.like() == outcome.get("like", "")
+        assert self.distro.codename() == outcome.get("codename", "")
 
     def test_linuxmint17_lsb_release(self):
         desired_outcome = {
-            'id': 'linuxmint',
-            'name': 'LinuxMint',
-            'pretty_name': 'Linux Mint 17.3 Rosa',
-            'version': '17.3',
-            'pretty_version': '17.3 (rosa)',
-            'best_version': '17.3',
-            'codename': 'rosa'
+            "id": "linuxmint",
+            "name": "LinuxMint",
+            "pretty_name": "Linux Mint 17.3 Rosa",
+            "version": "17.3",
+            "pretty_version": "17.3 (rosa)",
+            "best_version": "17.3",
+            "codename": "rosa",
         }
         self._test_outcome(desired_outcome)
 
     def test_manjaro1512_lsb_release(self):
-        self._test_outcome({
-            'id': 'manjarolinux',
-            'name': 'ManjaroLinux',
-            'pretty_name': 'Manjaro Linux',
-            'version': '15.12',
-            'pretty_version': '15.12 (Capella)',
-            'best_version': '15.12',
-            'codename': 'Capella'
-        })
+        self._test_outcome(
+            {
+                "id": "manjarolinux",
+                "name": "ManjaroLinux",
+                "pretty_name": "Manjaro Linux",
+                "version": "15.12",
+                "pretty_version": "15.12 (Capella)",
+                "best_version": "15.12",
+                "codename": "Capella",
+            }
+        )
 
     # @pytest.mark.xfail
     # def test_openelec6_lsb_release(self):
@@ -539,465 +540,475 @@ class TestLSBRelease(DistroTestCase):
     #     self._test_outcome(desired_outcome)
 
     def test_openbsd62_uname(self):
-        self._test_outcome({
-            'id': 'openbsd',
-            'name': 'OpenBSD',
-            'version': '6.2',
-            'pretty_name': 'OpenBSD 6.2',
-            'pretty_version': '6.2',
-            'best_version': '6.2'
-        })
+        self._test_outcome(
+            {
+                "id": "openbsd",
+                "name": "OpenBSD",
+                "version": "6.2",
+                "pretty_name": "OpenBSD 6.2",
+                "pretty_version": "6.2",
+                "best_version": "6.2",
+            }
+        )
 
     def test_netbsd711_uname(self):
-        self._test_outcome({
-            'id': 'netbsd',
-            'name': 'NetBSD',
-            'version': '7.1.1',
-            'pretty_name': 'NetBSD 7.1.1',
-            'pretty_version': '7.1.1',
-            'best_version': '7.1.1'
-        })
+        self._test_outcome(
+            {
+                "id": "netbsd",
+                "name": "NetBSD",
+                "version": "7.1.1",
+                "pretty_name": "NetBSD 7.1.1",
+                "pretty_version": "7.1.1",
+                "best_version": "7.1.1",
+            }
+        )
 
     def test_freebsd111_uname(self):
-        self._test_outcome({
-            'id': 'freebsd',
-            'name': 'FreeBSD',
-            'version': '11.1',
-            'pretty_name': 'FreeBSD 11.1',
-            'pretty_version': '11.1',
-            'best_version': '11.1'
-        })
+        self._test_outcome(
+            {
+                "id": "freebsd",
+                "name": "FreeBSD",
+                "version": "11.1",
+                "pretty_name": "FreeBSD 11.1",
+                "pretty_version": "11.1",
+                "best_version": "11.1",
+            }
+        )
 
     def test_midnightbsd12_uname(self):
-        self._test_outcome({
-            'id': 'midnightbsd',
-            'name': 'MidnightBSD',
-            'version': '1.2',
-            'pretty_name': 'MidnightBSD 1.2',
-            'pretty_version': '1.2',
-            'best_version': '1.2'
-        })
+        self._test_outcome(
+            {
+                "id": "midnightbsd",
+                "name": "MidnightBSD",
+                "version": "1.2",
+                "pretty_name": "MidnightBSD 1.2",
+                "pretty_version": "1.2",
+                "best_version": "1.2",
+            }
+        )
 
     def test_ubuntu14normal_lsb_release(self):
-        self._setup_for_distro(os.path.join(TESTDISTROS, 'lsb',
-                                            'ubuntu14_normal'))
+        self._setup_for_distro(os.path.join(TESTDISTROS, "lsb", "ubuntu14_normal"))
 
         self.distro = distro.LinuxDistribution(
             include_lsb=True,
-            os_release_file='path-to-non-existing-file',
-            distro_release_file='path-to-non-existing-file')
+            os_release_file="path-to-non-existing-file",
+            distro_release_file="path-to-non-existing-file",
+        )
 
         desired_outcome = {
-            'id': 'ubuntu',
-            'name': 'Ubuntu',
-            'pretty_name': 'Ubuntu 14.04.3 LTS',
-            'version': '14.04',
-            'pretty_version': '14.04 (trusty)',
-            'best_version': '14.04.3',
-            'codename': 'trusty'
+            "id": "ubuntu",
+            "name": "Ubuntu",
+            "pretty_name": "Ubuntu 14.04.3 LTS",
+            "version": "14.04",
+            "pretty_version": "14.04 (trusty)",
+            "best_version": "14.04.3",
+            "codename": "trusty",
         }
         self._test_outcome(desired_outcome)
 
     def test_ubuntu14nomodules_lsb_release(self):
-        self._setup_for_distro(os.path.join(TESTDISTROS, 'lsb',
-                                            'ubuntu14_nomodules'))
+        self._setup_for_distro(os.path.join(TESTDISTROS, "lsb", "ubuntu14_nomodules"))
 
         self.distro = distro.LinuxDistribution(
             include_lsb=True,
-            os_release_file='path-to-non-existing-file',
-            distro_release_file='path-to-non-existing-file')
+            os_release_file="path-to-non-existing-file",
+            distro_release_file="path-to-non-existing-file",
+        )
 
         desired_outcome = {
-            'id': 'ubuntu',
-            'name': 'Ubuntu',
-            'pretty_name': 'Ubuntu 14.04.3 LTS',
-            'version': '14.04',
-            'pretty_version': '14.04 (trusty)',
-            'best_version': '14.04.3',
-            'codename': 'trusty'
+            "id": "ubuntu",
+            "name": "Ubuntu",
+            "pretty_name": "Ubuntu 14.04.3 LTS",
+            "version": "14.04",
+            "pretty_version": "14.04 (trusty)",
+            "best_version": "14.04.3",
+            "codename": "trusty",
         }
         self._test_outcome(desired_outcome)
 
     def test_trailingblanks_lsb_release(self):
-        self._setup_for_distro(os.path.join(TESTDISTROS, 'lsb',
-                                            'ubuntu14_trailingblanks'))
+        self._setup_for_distro(
+            os.path.join(TESTDISTROS, "lsb", "ubuntu14_trailingblanks")
+        )
 
         self.distro = distro.LinuxDistribution(
             include_lsb=True,
-            os_release_file='path-to-non-existing-file',
-            distro_release_file='path-to-non-existing-file')
+            os_release_file="path-to-non-existing-file",
+            distro_release_file="path-to-non-existing-file",
+        )
 
         desired_outcome = {
-            'id': 'ubuntu',
-            'name': 'Ubuntu',
-            'pretty_name': 'Ubuntu 14.04.3 LTS',
-            'version': '14.04',
-            'pretty_version': '14.04 (trusty)',
-            'best_version': '14.04.3',
-            'codename': 'trusty'
+            "id": "ubuntu",
+            "name": "Ubuntu",
+            "pretty_name": "Ubuntu 14.04.3 LTS",
+            "version": "14.04",
+            "pretty_version": "14.04 (trusty)",
+            "best_version": "14.04.3",
+            "codename": "trusty",
         }
         self._test_outcome(desired_outcome)
 
-    @pytest.mark.parametrize('errnum', ('001', '002', '126', '130', '255'))
+    @pytest.mark.parametrize("errnum", ("001", "002", "126", "130", "255"))
     def test_lsb_release_error_level(self, errnum):
-        self._setup_for_distro(os.path.join(
-            TESTDISTROS, 'lsb', 'lsb_rc{0}'.format(errnum)))
+        self._setup_for_distro(
+            os.path.join(TESTDISTROS, "lsb", "lsb_rc{0}".format(errnum))
+        )
 
         lsb_release_info = distro.LinuxDistribution(
             include_lsb=True,
-            os_release_file='path-to-non-existing-file',
-            distro_release_file='path-to-non-existing-file')._lsb_release_info
+            os_release_file="path-to-non-existing-file",
+            distro_release_file="path-to-non-existing-file",
+        )._lsb_release_info
 
         assert lsb_release_info == {}
 
 
-@pytest.mark.skipif(not IS_LINUX, reason='Irrelevant on non-linux')
+@pytest.mark.skipif(not IS_LINUX, reason="Irrelevant on non-linux")
 class TestSpecialRelease(DistroTestCase):
     def _test_outcome(self, outcome):
-        assert self.distro.id() == outcome.get('id', '')
-        assert self.distro.name() == outcome.get('name', '')
-        assert self.distro.name(pretty=True) == outcome.get('pretty_name', '')
-        assert self.distro.version() == outcome.get('version', '')
-        assert self.distro.version(pretty=True) == \
-            outcome.get('pretty_version', '')
-        assert self.distro.version(best=True) == \
-            outcome.get('best_version', '')
-        assert self.distro.like() == outcome.get('like', '')
-        assert self.distro.codename() == outcome.get('codename', '')
-        assert self.distro.major_version() == outcome.get('major_version', '')
-        assert self.distro.minor_version() == outcome.get('minor_version', '')
-        assert self.distro.build_number() == outcome.get('build_number', '')
+        assert self.distro.id() == outcome.get("id", "")
+        assert self.distro.name() == outcome.get("name", "")
+        assert self.distro.name(pretty=True) == outcome.get("pretty_name", "")
+        assert self.distro.version() == outcome.get("version", "")
+        assert self.distro.version(pretty=True) == outcome.get("pretty_version", "")
+        assert self.distro.version(best=True) == outcome.get("best_version", "")
+        assert self.distro.like() == outcome.get("like", "")
+        assert self.distro.codename() == outcome.get("codename", "")
+        assert self.distro.major_version() == outcome.get("major_version", "")
+        assert self.distro.minor_version() == outcome.get("minor_version", "")
+        assert self.distro.build_number() == outcome.get("build_number", "")
 
     def test_empty_release(self):
-        distro_release = os.path.join(SPECIAL, 'empty-release')
+        distro_release = os.path.join(SPECIAL, "empty-release")
 
         self.distro = distro.LinuxDistribution(
             include_lsb=False,
-            os_release_file='path-to-non-existing-file',
-            distro_release_file=distro_release)
+            os_release_file="path-to-non-existing-file",
+            distro_release_file=distro_release,
+        )
 
-        desired_outcome = {
-            'id': 'empty'
-        }
+        desired_outcome = {"id": "empty"}
         self._test_outcome(desired_outcome)
 
     def test_unknowndistro_release(self):
-        self._setup_for_distro(os.path.join(TESTDISTROS, 'distro',
-                                            'unknowndistro'))
+        self._setup_for_distro(os.path.join(TESTDISTROS, "distro", "unknowndistro"))
 
         self.distro = distro.LinuxDistribution()
 
         desired_outcome = {
-            'id': 'unknowndistro',
-            'name': 'Unknown Distro',
-            'pretty_name': 'Unknown Distro 1.0 (Unknown Codename)',
-            'version': '1.0',
-            'pretty_version': '1.0 (Unknown Codename)',
-            'best_version': '1.0',
-            'codename': 'Unknown Codename',
-            'major_version': '1',
-            'minor_version': '0'
+            "id": "unknowndistro",
+            "name": "Unknown Distro",
+            "pretty_name": "Unknown Distro 1.0 (Unknown Codename)",
+            "version": "1.0",
+            "pretty_version": "1.0 (Unknown Codename)",
+            "best_version": "1.0",
+            "codename": "Unknown Codename",
+            "major_version": "1",
+            "minor_version": "0",
         }
         self._test_outcome(desired_outcome)
 
     def test_bad_uname(self):
-        self._setup_for_distro(os.path.join(TESTDISTROS, 'distro',
-                                            'baduname'))
+        self._setup_for_distro(os.path.join(TESTDISTROS, "distro", "baduname"))
         self.distro = distro.LinuxDistribution()
 
-        assert self.distro.uname_attr('id') == ''
-        assert self.distro.uname_attr('name') == ''
-        assert self.distro.uname_attr('release') == ''
+        assert self.distro.uname_attr("id") == ""
+        assert self.distro.uname_attr("name") == ""
+        assert self.distro.uname_attr("release") == ""
 
 
-@pytest.mark.skipif(not IS_LINUX, reason='Irrelevant on non-linux')
+@pytest.mark.skipif(not IS_LINUX, reason="Irrelevant on non-linux")
 class TestDistroRelease:
-
-    def _test_outcome(self,
-                      outcome,
-                      distro_name='',
-                      version='',
-                      release_file_id='',
-                      release_file_suffix='release'):
+    def _test_outcome(
+        self,
+        outcome,
+        distro_name="",
+        version="",
+        release_file_id="",
+        release_file_suffix="release",
+    ):
         release_file_id = release_file_id or distro_name
         distro_release = os.path.join(
-            DISTROS_DIR, distro_name + version, 'etc', '{0}-{1}'.format(
-                release_file_id, release_file_suffix))
+            DISTROS_DIR,
+            distro_name + version,
+            "etc",
+            "{0}-{1}".format(release_file_id, release_file_suffix),
+        )
         self.distro = distro.LinuxDistribution(
             include_lsb=False,
-            os_release_file='path-to-non-existing-file',
-            distro_release_file=distro_release)
+            os_release_file="path-to-non-existing-file",
+            distro_release_file=distro_release,
+        )
 
-        assert self.distro.id() == outcome.get('id', '')
-        assert self.distro.name() == outcome.get('name', '')
-        assert self.distro.name(pretty=True) == outcome.get('pretty_name', '')
-        assert self.distro.version() == outcome.get('version', '')
-        assert self.distro.version(pretty=True) == \
-            outcome.get('pretty_version', '')
-        assert self.distro.version(best=True) == \
-            outcome.get('best_version', '')
-        assert self.distro.like() == outcome.get('like', '')
-        assert self.distro.codename() == outcome.get('codename', '')
-        assert self.distro.major_version() == outcome.get('major_version', '')
-        assert self.distro.minor_version() == outcome.get('minor_version', '')
-        assert self.distro.build_number() == outcome.get('build_number', '')
+        assert self.distro.id() == outcome.get("id", "")
+        assert self.distro.name() == outcome.get("name", "")
+        assert self.distro.name(pretty=True) == outcome.get("pretty_name", "")
+        assert self.distro.version() == outcome.get("version", "")
+        assert self.distro.version(pretty=True) == outcome.get("pretty_version", "")
+        assert self.distro.version(best=True) == outcome.get("best_version", "")
+        assert self.distro.like() == outcome.get("like", "")
+        assert self.distro.codename() == outcome.get("codename", "")
+        assert self.distro.major_version() == outcome.get("major_version", "")
+        assert self.distro.minor_version() == outcome.get("minor_version", "")
+        assert self.distro.build_number() == outcome.get("build_number", "")
 
     def test_arch_dist_release(self):
-        desired_outcome = {
-            'id': 'arch'
-        }
-        self._test_outcome(desired_outcome, 'arch')
+        desired_outcome = {"id": "arch"}
+        self._test_outcome(desired_outcome, "arch")
 
     def test_centos5_dist_release(self):
         desired_outcome = {
-            'id': 'centos',
-            'name': 'CentOS',
-            'pretty_name': 'CentOS 5.11 (Final)',
-            'version': '5.11',
-            'pretty_version': '5.11 (Final)',
-            'best_version': '5.11',
-            'codename': 'Final',
-            'major_version': '5',
-            'minor_version': '11'
+            "id": "centos",
+            "name": "CentOS",
+            "pretty_name": "CentOS 5.11 (Final)",
+            "version": "5.11",
+            "pretty_version": "5.11 (Final)",
+            "best_version": "5.11",
+            "codename": "Final",
+            "major_version": "5",
+            "minor_version": "11",
         }
-        self._test_outcome(desired_outcome, 'centos', '5')
+        self._test_outcome(desired_outcome, "centos", "5")
 
     def test_centos7_dist_release(self):
         desired_outcome = {
-            'id': 'centos',
-            'name': 'CentOS Linux',
-            'pretty_name': 'CentOS Linux 7.1.1503 (Core)',
-            'version': '7.1.1503',
-            'pretty_version': '7.1.1503 (Core)',
-            'best_version': '7.1.1503',
-            'codename': 'Core',
-            'major_version': '7',
-            'minor_version': '1',
-            'build_number': '1503'
+            "id": "centos",
+            "name": "CentOS Linux",
+            "pretty_name": "CentOS Linux 7.1.1503 (Core)",
+            "version": "7.1.1503",
+            "pretty_version": "7.1.1503 (Core)",
+            "best_version": "7.1.1503",
+            "codename": "Core",
+            "major_version": "7",
+            "minor_version": "1",
+            "build_number": "1503",
         }
-        self._test_outcome(desired_outcome, 'centos', '7')
+        self._test_outcome(desired_outcome, "centos", "7")
 
     def test_fedora19_dist_release(self):
         desired_outcome = {
-            'id': 'fedora',
-            'name': 'Fedora',
-            'pretty_name': 'Fedora 19 (Schrödinger’s Cat)',
-            'version': '19',
-            'pretty_version': '19 (Schrödinger’s Cat)',
-            'best_version': '19',
-            'codename': 'Schrödinger’s Cat',
-            'major_version': '19'
+            "id": "fedora",
+            "name": "Fedora",
+            "pretty_name": "Fedora 19 (Schrödinger’s Cat)",
+            "version": "19",
+            "pretty_version": "19 (Schrödinger’s Cat)",
+            "best_version": "19",
+            "codename": "Schrödinger’s Cat",
+            "major_version": "19",
         }
-        self._test_outcome(desired_outcome, 'fedora', '19')
+        self._test_outcome(desired_outcome, "fedora", "19")
 
     def test_fedora23_dist_release(self):
         desired_outcome = {
-            'id': 'fedora',
-            'name': 'Fedora',
-            'pretty_name': 'Fedora 23 (Twenty Three)',
-            'version': '23',
-            'pretty_version': '23 (Twenty Three)',
-            'best_version': '23',
-            'codename': 'Twenty Three',
-            'major_version': '23'
+            "id": "fedora",
+            "name": "Fedora",
+            "pretty_name": "Fedora 23 (Twenty Three)",
+            "version": "23",
+            "pretty_version": "23 (Twenty Three)",
+            "best_version": "23",
+            "codename": "Twenty Three",
+            "major_version": "23",
         }
-        self._test_outcome(desired_outcome, 'fedora', '23')
+        self._test_outcome(desired_outcome, "fedora", "23")
 
     def test_fedora30_dist_release(self):
         desired_outcome = {
-            'id': 'fedora',
-            'name': 'Fedora',
-            'pretty_name': 'Fedora 30 (Thirty)',
-            'version': '30',
-            'pretty_version': '30 (Thirty)',
-            'best_version': '30',
-            'codename': 'Thirty',
-            'major_version': '30'
+            "id": "fedora",
+            "name": "Fedora",
+            "pretty_name": "Fedora 30 (Thirty)",
+            "version": "30",
+            "pretty_version": "30 (Thirty)",
+            "best_version": "30",
+            "codename": "Thirty",
+            "major_version": "30",
         }
-        self._test_outcome(desired_outcome, 'fedora', '30')
+        self._test_outcome(desired_outcome, "fedora", "30")
 
     def test_gentoo_dist_release(self):
         desired_outcome = {
-            'id': 'gentoo',
-            'name': 'Gentoo Base System',
-            'pretty_name': 'Gentoo Base System 2.2',
-            'version': '2.2',
-            'pretty_version': '2.2',
-            'best_version': '2.2',
-            'major_version': '2',
-            'minor_version': '2',
+            "id": "gentoo",
+            "name": "Gentoo Base System",
+            "pretty_name": "Gentoo Base System 2.2",
+            "version": "2.2",
+            "pretty_version": "2.2",
+            "best_version": "2.2",
+            "major_version": "2",
+            "minor_version": "2",
         }
-        self._test_outcome(desired_outcome, 'gentoo')
+        self._test_outcome(desired_outcome, "gentoo")
 
     def test_kvmibm1_dist_release(self):
         desired_outcome = {
-            'id': 'base',
-            'name': 'KVM for IBM z Systems',
-            'pretty_name': 'KVM for IBM z Systems 1.1.1 (Z)',
-            'version': '1.1.1',
-            'pretty_version': '1.1.1 (Z)',
-            'best_version': '1.1.1',
-            'codename': 'Z',
-            'major_version': '1',
-            'minor_version': '1',
-            'build_number': '1'
+            "id": "base",
+            "name": "KVM for IBM z Systems",
+            "pretty_name": "KVM for IBM z Systems 1.1.1 (Z)",
+            "version": "1.1.1",
+            "pretty_version": "1.1.1 (Z)",
+            "best_version": "1.1.1",
+            "codename": "Z",
+            "major_version": "1",
+            "minor_version": "1",
+            "build_number": "1",
         }
-        self._test_outcome(desired_outcome, 'kvmibm', '1', 'base')
+        self._test_outcome(desired_outcome, "kvmibm", "1", "base")
 
     def test_mageia5_dist_release(self):
         desired_outcome = {
-            'id': 'mageia',
-            'name': 'Mageia',
-            'pretty_name': 'Mageia 5 (Official)',
-            'version': '5',
-            'pretty_version': '5 (Official)',
-            'best_version': '5',
-            'codename': 'Official',
-            'major_version': '5'
+            "id": "mageia",
+            "name": "Mageia",
+            "pretty_name": "Mageia 5 (Official)",
+            "version": "5",
+            "pretty_version": "5 (Official)",
+            "best_version": "5",
+            "codename": "Official",
+            "major_version": "5",
         }
-        self._test_outcome(desired_outcome, 'mageia', '5')
+        self._test_outcome(desired_outcome, "mageia", "5")
 
     def test_manjaro1512_dist_release(self):
-        self._test_outcome({
-            'id': 'manjaro',
-            'name': 'Manjaro Linux',
-            'pretty_name': 'Manjaro Linux',
-            'version': '',
-            'codename': ''
-        }, 'manjaro', '1512')
+        self._test_outcome(
+            {
+                "id": "manjaro",
+                "name": "Manjaro Linux",
+                "pretty_name": "Manjaro Linux",
+                "version": "",
+                "codename": "",
+            },
+            "manjaro",
+            "1512",
+        )
 
     def test_opensuse42_dist_release(self):
         desired_outcome = {
-            'id': 'suse',
-            'name': 'openSUSE',
-            'pretty_name': 'openSUSE 42.1 (x86_64)',
-            'version': '42.1',
-            'pretty_version': '42.1 (x86_64)',
-            'best_version': '42.1',
-            'codename': 'x86_64',
-            'major_version': '42',
-            'minor_version': '1'
+            "id": "suse",
+            "name": "openSUSE",
+            "pretty_name": "openSUSE 42.1 (x86_64)",
+            "version": "42.1",
+            "pretty_version": "42.1 (x86_64)",
+            "best_version": "42.1",
+            "codename": "x86_64",
+            "major_version": "42",
+            "minor_version": "1",
         }
-        self._test_outcome(desired_outcome, 'opensuse', '42', 'SuSE')
+        self._test_outcome(desired_outcome, "opensuse", "42", "SuSE")
 
     def test_oracle7_dist_release(self):
         desired_outcome = {
-            'id': 'oracle',
-            'name': 'Oracle Linux Server',
-            'pretty_name': 'Oracle Linux Server 7.5',
-            'version': '7.5',
-            'pretty_version': '7.5',
-            'best_version': '7.5',
-            'major_version': '7',
-            'minor_version': '5'
+            "id": "oracle",
+            "name": "Oracle Linux Server",
+            "pretty_name": "Oracle Linux Server 7.5",
+            "version": "7.5",
+            "pretty_version": "7.5",
+            "best_version": "7.5",
+            "major_version": "7",
+            "minor_version": "5",
         }
-        self._test_outcome(desired_outcome, 'oracle', '7')
+        self._test_outcome(desired_outcome, "oracle", "7")
 
     def test_rhel6_dist_release(self):
         desired_outcome = {
-            'id': 'rhel',
-            'name': 'Red Hat Enterprise Linux Server',
-            'pretty_name': 'Red Hat Enterprise Linux Server 6.5 (Santiago)',
-            'version': '6.5',
-            'pretty_version': '6.5 (Santiago)',
-            'best_version': '6.5',
-            'codename': 'Santiago',
-            'major_version': '6',
-            'minor_version': '5'
+            "id": "rhel",
+            "name": "Red Hat Enterprise Linux Server",
+            "pretty_name": "Red Hat Enterprise Linux Server 6.5 (Santiago)",
+            "version": "6.5",
+            "pretty_version": "6.5 (Santiago)",
+            "best_version": "6.5",
+            "codename": "Santiago",
+            "major_version": "6",
+            "minor_version": "5",
         }
-        self._test_outcome(desired_outcome, 'rhel', '6', 'redhat')
+        self._test_outcome(desired_outcome, "rhel", "6", "redhat")
 
     def test_rhel7_dist_release(self):
         desired_outcome = {
-            'id': 'rhel',
-            'name': 'Red Hat Enterprise Linux Server',
-            'pretty_name': 'Red Hat Enterprise Linux Server 7.0 (Maipo)',
-            'version': '7.0',
-            'pretty_version': '7.0 (Maipo)',
-            'best_version': '7.0',
-            'codename': 'Maipo',
-            'major_version': '7',
-            'minor_version': '0'
+            "id": "rhel",
+            "name": "Red Hat Enterprise Linux Server",
+            "pretty_name": "Red Hat Enterprise Linux Server 7.0 (Maipo)",
+            "version": "7.0",
+            "pretty_version": "7.0 (Maipo)",
+            "best_version": "7.0",
+            "codename": "Maipo",
+            "major_version": "7",
+            "minor_version": "0",
         }
-        self._test_outcome(desired_outcome, 'rhel', '7', 'redhat')
+        self._test_outcome(desired_outcome, "rhel", "7", "redhat")
 
     def test_slackware14_dist_release(self):
         desired_outcome = {
-            'id': 'slackware',
-            'name': 'Slackware',
-            'pretty_name': 'Slackware 14.1',
-            'version': '14.1',
-            'pretty_version': '14.1',
-            'best_version': '14.1',
-            'major_version': '14',
-            'minor_version': '1'
+            "id": "slackware",
+            "name": "Slackware",
+            "pretty_name": "Slackware 14.1",
+            "version": "14.1",
+            "pretty_version": "14.1",
+            "best_version": "14.1",
+            "major_version": "14",
+            "minor_version": "1",
         }
         self._test_outcome(
-            desired_outcome,
-            'slackware',
-            '14',
-            release_file_suffix='version')
+            desired_outcome, "slackware", "14", release_file_suffix="version"
+        )
 
     def test_sles12_dist_release(self):
         desired_outcome = {
-            'id': 'suse',
-            'name': 'SUSE Linux Enterprise Server',
-            'pretty_name': 'SUSE Linux Enterprise Server 12 (s390x)',
-            'version': '12',
-            'pretty_version': '12 (s390x)',
-            'best_version': '12',
-            'major_version': '12',
-            'codename': 's390x'
+            "id": "suse",
+            "name": "SUSE Linux Enterprise Server",
+            "pretty_name": "SUSE Linux Enterprise Server 12 (s390x)",
+            "version": "12",
+            "pretty_version": "12 (s390x)",
+            "best_version": "12",
+            "major_version": "12",
+            "codename": "s390x",
         }
-        self._test_outcome(desired_outcome, 'sles', '12', 'SuSE')
+        self._test_outcome(desired_outcome, "sles", "12", "SuSE")
 
     def test_cloudlinux5_dist_release(self):
         # Uses redhat-release only to get information.
         # The id of 'rhel' can only be fixed with issue #109.
         desired_outcome = {
-            'id': 'cloudlinux',
-            'codename': 'Vladislav Volkov',
-            'name': 'CloudLinux Server',
-            'pretty_name': 'CloudLinux Server 5.11 (Vladislav Volkov)',
-            'version': '5.11',
-            'pretty_version': '5.11 (Vladislav Volkov)',
-            'best_version': '5.11',
-            'major_version': '5',
-            'minor_version': '11'
+            "id": "cloudlinux",
+            "codename": "Vladislav Volkov",
+            "name": "CloudLinux Server",
+            "pretty_name": "CloudLinux Server 5.11 (Vladislav Volkov)",
+            "version": "5.11",
+            "pretty_version": "5.11 (Vladislav Volkov)",
+            "best_version": "5.11",
+            "major_version": "5",
+            "minor_version": "11",
         }
-        self._test_outcome(desired_outcome, 'cloudlinux', '5', 'redhat')
+        self._test_outcome(desired_outcome, "cloudlinux", "5", "redhat")
 
     def test_cloudlinux6_dist_release(self):
         # Same as above, only has redhat-release.
         desired_outcome = {
-            'id': 'cloudlinux',
-            'codename': 'Oleg Makarov',
-            'name': 'CloudLinux Server',
-            'pretty_name': 'CloudLinux Server 6.8 (Oleg Makarov)',
-            'version': '6.8',
-            'pretty_version': '6.8 (Oleg Makarov)',
-            'best_version': '6.8',
-            'major_version': '6',
-            'minor_version': '8'
+            "id": "cloudlinux",
+            "codename": "Oleg Makarov",
+            "name": "CloudLinux Server",
+            "pretty_name": "CloudLinux Server 6.8 (Oleg Makarov)",
+            "version": "6.8",
+            "pretty_version": "6.8 (Oleg Makarov)",
+            "best_version": "6.8",
+            "major_version": "6",
+            "minor_version": "8",
         }
-        self._test_outcome(desired_outcome, 'cloudlinux', '6', 'redhat')
+        self._test_outcome(desired_outcome, "cloudlinux", "6", "redhat")
 
     def test_cloudlinux7_dist_release(self):
         desired_outcome = {
-            'id': 'cloudlinux',
-            'codename': 'Yury Malyshev',
-            'name': 'CloudLinux',
-            'pretty_name': 'CloudLinux 7.3 (Yury Malyshev)',
-            'version': '7.3',
-            'pretty_version': '7.3 (Yury Malyshev)',
-            'best_version': '7.3',
-            'major_version': '7',
-            'minor_version': '3'
+            "id": "cloudlinux",
+            "codename": "Yury Malyshev",
+            "name": "CloudLinux",
+            "pretty_name": "CloudLinux 7.3 (Yury Malyshev)",
+            "version": "7.3",
+            "pretty_version": "7.3 (Yury Malyshev)",
+            "best_version": "7.3",
+            "major_version": "7",
+            "minor_version": "3",
         }
-        self._test_outcome(desired_outcome, 'cloudlinux', '7', 'redhat')
+        self._test_outcome(desired_outcome, "cloudlinux", "7", "redhat")
 
 
-@pytest.mark.skipif(not IS_LINUX, reason='Irrelevant on non-linux')
+@pytest.mark.skipif(not IS_LINUX, reason="Irrelevant on non-linux")
 class TestOverall(DistroTestCase):
     """Test a LinuxDistribution object created with default arguments.
 
@@ -1025,29 +1036,27 @@ class TestOverall(DistroTestCase):
 
     def setup_method(self, test_method):
         super(TestOverall, self).setup_method(test_method)
-        dist = test_method.__name__.split('_')[1]
+        dist = test_method.__name__.split("_")[1]
         self._setup_for_distro(os.path.join(DISTROS_DIR, dist))
         self.distro = distro.LinuxDistribution()
 
     def _test_outcome(self, outcome):
-        assert self.distro.id() == outcome.get('id', '')
-        assert self.distro.name() == outcome.get('name', '')
-        assert self.distro.name(pretty=True) == outcome.get('pretty_name', '')
-        assert self.distro.version() == outcome.get('version', '')
-        assert self.distro.version(pretty=True) == \
-            outcome.get('pretty_version', '')
-        assert self.distro.version(best=True) == \
-            outcome.get('best_version', '')
-        assert self.distro.like() == outcome.get('like', '')
-        assert self.distro.codename() == outcome.get('codename', '')
-        assert self.distro.major_version() == outcome.get('major_version', '')
-        assert self.distro.minor_version() == outcome.get('minor_version', '')
-        assert self.distro.build_number() == outcome.get('build_number', '')
+        assert self.distro.id() == outcome.get("id", "")
+        assert self.distro.name() == outcome.get("name", "")
+        assert self.distro.name(pretty=True) == outcome.get("pretty_name", "")
+        assert self.distro.version() == outcome.get("version", "")
+        assert self.distro.version(pretty=True) == outcome.get("pretty_version", "")
+        assert self.distro.version(best=True) == outcome.get("best_version", "")
+        assert self.distro.like() == outcome.get("like", "")
+        assert self.distro.codename() == outcome.get("codename", "")
+        assert self.distro.major_version() == outcome.get("major_version", "")
+        assert self.distro.minor_version() == outcome.get("minor_version", "")
+        assert self.distro.build_number() == outcome.get("build_number", "")
 
     def _test_non_existing_release_file(self):
         # Test the info from the searched distro release file
         # does not have one.
-        assert self.distro.distro_release_file == ''
+        assert self.distro.distro_release_file == ""
         assert len(self.distro.distro_release_info()) == 0
 
     def _test_release_file_info(self, filename, outcome):
@@ -1060,9 +1069,9 @@ class TestOverall(DistroTestCase):
 
     def test_arch_release(self):
         desired_outcome = {
-            'id': 'arch',
-            'name': 'Arch Linux',
-            'pretty_name': 'Arch Linux',
+            "id": "arch",
+            "name": "Arch Linux",
+            "pretty_name": "Arch Linux",
         }
         self._test_outcome(desired_outcome)
 
@@ -1073,427 +1082,426 @@ class TestOverall(DistroTestCase):
 
     def test_centos5_release(self):
         desired_outcome = {
-            'id': 'centos',
-            'name': 'CentOS',
-            'pretty_name': 'CentOS 5.11 (Final)',
-            'version': '5.11',
-            'pretty_version': '5.11 (Final)',
-            'best_version': '5.11',
-            'codename': 'Final',
-            'major_version': '5',
-            'minor_version': '11'
+            "id": "centos",
+            "name": "CentOS",
+            "pretty_name": "CentOS 5.11 (Final)",
+            "version": "5.11",
+            "pretty_version": "5.11 (Final)",
+            "best_version": "5.11",
+            "codename": "Final",
+            "major_version": "5",
+            "minor_version": "11",
         }
         self._test_outcome(desired_outcome)
 
         desired_info = {
-            'id': 'centos',
-            'name': 'CentOS',
-            'version_id': '5.11',
-            'codename': 'Final'
+            "id": "centos",
+            "name": "CentOS",
+            "version_id": "5.11",
+            "codename": "Final",
         }
-        self._test_release_file_info('centos-release', desired_info)
+        self._test_release_file_info("centos-release", desired_info)
 
     def test_centos7_release(self):
         desired_outcome = {
-            'id': 'centos',
-            'name': 'CentOS Linux',
-            'pretty_name': 'CentOS Linux 7 (Core)',
-            'version': '7',
-            'pretty_version': '7 (Core)',
-            'best_version': '7.1.1503',
-            'like': 'rhel fedora',
-            'codename': 'Core',
-            'major_version': '7'
+            "id": "centos",
+            "name": "CentOS Linux",
+            "pretty_name": "CentOS Linux 7 (Core)",
+            "version": "7",
+            "pretty_version": "7 (Core)",
+            "best_version": "7.1.1503",
+            "like": "rhel fedora",
+            "codename": "Core",
+            "major_version": "7",
         }
         self._test_outcome(desired_outcome)
 
         desired_info = {
-            'id': 'centos',
-            'name': 'CentOS Linux',
-            'version_id': '7.1.1503',
-            'codename': 'Core'
+            "id": "centos",
+            "name": "CentOS Linux",
+            "version_id": "7.1.1503",
+            "codename": "Core",
         }
-        self._test_release_file_info('centos-release', desired_info)
+        self._test_release_file_info("centos-release", desired_info)
 
     def test_coreos_release(self):
         desired_outcome = {
-            'id': 'coreos',
-            'name': 'CoreOS',
-            'pretty_name': 'CoreOS 899.15.0',
-            'version': '899.15.0',
-            'pretty_version': '899.15.0',
-            'best_version': '899.15.0',
-            'major_version': '899',
-            'minor_version': '15',
-            'build_number': '0'
+            "id": "coreos",
+            "name": "CoreOS",
+            "pretty_name": "CoreOS 899.15.0",
+            "version": "899.15.0",
+            "pretty_version": "899.15.0",
+            "best_version": "899.15.0",
+            "major_version": "899",
+            "minor_version": "15",
+            "build_number": "0",
         }
         self._test_outcome(desired_outcome)
         self._test_non_existing_release_file()
 
     def test_debian8_release(self):
         desired_outcome = {
-            'id': 'debian',
-            'name': 'Debian GNU/Linux',
-            'pretty_name': 'Debian GNU/Linux 8 (jessie)',
-            'version': '8',
-            'pretty_version': '8 (jessie)',
-            'best_version': '8.2',
-            'codename': 'jessie',
-            'major_version': '8'
+            "id": "debian",
+            "name": "Debian GNU/Linux",
+            "pretty_name": "Debian GNU/Linux 8 (jessie)",
+            "version": "8",
+            "pretty_version": "8 (jessie)",
+            "best_version": "8.2",
+            "codename": "jessie",
+            "major_version": "8",
         }
         self._test_outcome(desired_outcome)
         self._test_non_existing_release_file()
 
     def test_exherbo_release(self):
         desired_outcome = {
-            'id': 'exherbo',
-            'name': 'Exherbo',
-            'pretty_name': 'Exherbo Linux',
+            "id": "exherbo",
+            "name": "Exherbo",
+            "pretty_name": "Exherbo Linux",
         }
         self._test_outcome(desired_outcome)
 
     def test_fedora19_release(self):
         desired_outcome = {
-            'id': 'fedora',
-            'name': 'Fedora',
-            'pretty_name': 'Fedora 19 (Schrödinger’s Cat)',
-            'version': '19',
-            'pretty_version': '19 (Schrödinger’s Cat)',
-            'best_version': '19',
-            'codename': 'Schrödinger’s Cat',
-            'major_version': '19'
+            "id": "fedora",
+            "name": "Fedora",
+            "pretty_name": "Fedora 19 (Schrödinger’s Cat)",
+            "version": "19",
+            "pretty_version": "19 (Schrödinger’s Cat)",
+            "best_version": "19",
+            "codename": "Schrödinger’s Cat",
+            "major_version": "19",
         }
         self._test_outcome(desired_outcome)
 
         desired_info = {
-            'id': 'fedora',
-            'name': 'Fedora',
-            'version_id': '19',
-            'codename': 'Schrödinger’s Cat'
+            "id": "fedora",
+            "name": "Fedora",
+            "version_id": "19",
+            "codename": "Schrödinger’s Cat",
         }
-        self._test_release_file_info('fedora-release', desired_info)
+        self._test_release_file_info("fedora-release", desired_info)
 
     def test_fedora23_release(self):
         desired_outcome = {
-            'id': 'fedora',
-            'name': 'Fedora',
-            'pretty_name': 'Fedora 23 (Twenty Three)',
-            'version': '23',
-            'pretty_version': '23 (Twenty Three)',
-            'best_version': '23',
-            'codename': 'Twenty Three',
-            'major_version': '23'
+            "id": "fedora",
+            "name": "Fedora",
+            "pretty_name": "Fedora 23 (Twenty Three)",
+            "version": "23",
+            "pretty_version": "23 (Twenty Three)",
+            "best_version": "23",
+            "codename": "Twenty Three",
+            "major_version": "23",
         }
         self._test_outcome(desired_outcome)
 
         desired_info = {
-            'id': 'fedora',
-            'name': 'Fedora',
-            'version_id': '23',
-            'codename': 'Twenty Three'
+            "id": "fedora",
+            "name": "Fedora",
+            "version_id": "23",
+            "codename": "Twenty Three",
         }
-        self._test_release_file_info('fedora-release', desired_info)
+        self._test_release_file_info("fedora-release", desired_info)
 
     def test_fedora30_release(self):
         desired_outcome = {
-            'id': 'fedora',
-            'name': 'Fedora',
-            'pretty_name': 'Fedora 30 (Thirty)',
-            'version': '30',
-            'pretty_version': '30',
-            'best_version': '30',
-            'codename': '',
-            'major_version': '30'
+            "id": "fedora",
+            "name": "Fedora",
+            "pretty_name": "Fedora 30 (Thirty)",
+            "version": "30",
+            "pretty_version": "30",
+            "best_version": "30",
+            "codename": "",
+            "major_version": "30",
         }
         self._test_outcome(desired_outcome)
 
         desired_info = {
-            'id': 'fedora',
-            'name': 'Fedora',
-            'version_id': '30',
-            'codename': 'Thirty'
+            "id": "fedora",
+            "name": "Fedora",
+            "version_id": "30",
+            "codename": "Thirty",
         }
-        self._test_release_file_info('fedora-release', desired_info)
+        self._test_release_file_info("fedora-release", desired_info)
 
     def test_kvmibm1_release(self):
         desired_outcome = {
-            'id': 'kvmibm',
-            'name': 'KVM for IBM z Systems',
-            'pretty_name': 'KVM for IBM z Systems 1.1.1 (Z)',
-            'version': '1.1.1',
-            'pretty_version': '1.1.1 (Z)',
-            'best_version': '1.1.1',
-            'like': 'rhel fedora',
-            'codename': 'Z',
-            'major_version': '1',
-            'minor_version': '1',
-            'build_number': '1'
+            "id": "kvmibm",
+            "name": "KVM for IBM z Systems",
+            "pretty_name": "KVM for IBM z Systems 1.1.1 (Z)",
+            "version": "1.1.1",
+            "pretty_version": "1.1.1 (Z)",
+            "best_version": "1.1.1",
+            "like": "rhel fedora",
+            "codename": "Z",
+            "major_version": "1",
+            "minor_version": "1",
+            "build_number": "1",
         }
         self._test_outcome(desired_outcome)
 
         desired_info = {
-            'id': 'base',
-            'name': 'KVM for IBM z Systems',
-            'version_id': '1.1.1',
-            'codename': 'Z'
+            "id": "base",
+            "name": "KVM for IBM z Systems",
+            "version_id": "1.1.1",
+            "codename": "Z",
         }
-        self._test_release_file_info('base-release', desired_info)
+        self._test_release_file_info("base-release", desired_info)
 
     def test_linuxmint17_release(self):
         desired_outcome = {
-            'id': 'ubuntu',
-            'name': 'Ubuntu',
-            'pretty_name': 'Ubuntu 14.04.3 LTS',
-            'version': '14.04',
-            'pretty_version': '14.04 (Trusty Tahr)',
-            'best_version': '14.04.3',
-            'like': 'debian',
-            'codename': 'Trusty Tahr',
-            'major_version': '14',
-            'minor_version': '04'
+            "id": "ubuntu",
+            "name": "Ubuntu",
+            "pretty_name": "Ubuntu 14.04.3 LTS",
+            "version": "14.04",
+            "pretty_version": "14.04 (Trusty Tahr)",
+            "best_version": "14.04.3",
+            "like": "debian",
+            "codename": "Trusty Tahr",
+            "major_version": "14",
+            "minor_version": "04",
         }
         self._test_outcome(desired_outcome)
         self._test_non_existing_release_file()
 
     def test_mageia5_release(self):
         desired_outcome = {
-            'id': 'mageia',
-            'name': 'Mageia',
-            'pretty_name': 'Mageia 5',
-            'version': '5',
-            'pretty_version': '5 (thornicroft)',
-            'best_version': '5',
-            'like': 'mandriva fedora',
+            "id": "mageia",
+            "name": "Mageia",
+            "pretty_name": "Mageia 5",
+            "version": "5",
+            "pretty_version": "5 (thornicroft)",
+            "best_version": "5",
+            "like": "mandriva fedora",
             # TODO: Codename differs between distro release and lsb_release.
-            'codename': 'thornicroft',
-            'major_version': '5'
+            "codename": "thornicroft",
+            "major_version": "5",
         }
         self._test_outcome(desired_outcome)
 
         desired_info = {
-            'id': 'mageia',
-            'name': 'Mageia',
-            'version_id': '5',
-            'codename': 'Official'
+            "id": "mageia",
+            "name": "Mageia",
+            "version_id": "5",
+            "codename": "Official",
         }
-        self._test_release_file_info('mageia-release', desired_info)
+        self._test_release_file_info("mageia-release", desired_info)
 
     def test_manjaro1512_release(self):
-        self._test_outcome({
-            'id': 'manjaro',
-            'name': 'Manjaro Linux',
-            'pretty_name': 'Manjaro Linux',
-            'version': '15.12',
-            'pretty_version': '15.12 (Capella)',
-            'best_version': '15.12',
-            'major_version': '15',
-            'minor_version': '12',
-            'codename': 'Capella'
-        })
+        self._test_outcome(
+            {
+                "id": "manjaro",
+                "name": "Manjaro Linux",
+                "pretty_name": "Manjaro Linux",
+                "version": "15.12",
+                "pretty_version": "15.12 (Capella)",
+                "best_version": "15.12",
+                "major_version": "15",
+                "minor_version": "12",
+                "codename": "Capella",
+            }
+        )
 
         self._test_release_file_info(
-            'manjaro-release',
-            {'id': 'manjaro',
-             'name': 'Manjaro Linux'})
+            "manjaro-release", {"id": "manjaro", "name": "Manjaro Linux"}
+        )
 
     def test_opensuse42_release(self):
         desired_outcome = {
-            'id': 'opensuse',
-            'name': 'openSUSE Leap',
-            'pretty_name': 'openSUSE Leap 42.1 (x86_64)',
-            'version': '42.1',
-            'pretty_version': '42.1 (x86_64)',
-            'best_version': '42.1',
-            'like': 'suse',
-            'codename': 'x86_64',
-            'major_version': '42',
-            'minor_version': '1'
+            "id": "opensuse",
+            "name": "openSUSE Leap",
+            "pretty_name": "openSUSE Leap 42.1 (x86_64)",
+            "version": "42.1",
+            "pretty_version": "42.1 (x86_64)",
+            "best_version": "42.1",
+            "like": "suse",
+            "codename": "x86_64",
+            "major_version": "42",
+            "minor_version": "1",
         }
         self._test_outcome(desired_outcome)
 
         desired_info = {
-            'id': 'SuSE',
-            'name': 'openSUSE',
-            'version_id': '42.1',
-            'codename': 'x86_64'
+            "id": "SuSE",
+            "name": "openSUSE",
+            "version_id": "42.1",
+            "codename": "x86_64",
         }
-        self._test_release_file_info('SuSE-release', desired_info)
+        self._test_release_file_info("SuSE-release", desired_info)
 
     def test_oracle7_release(self):
         desired_outcome = {
-            'id': 'oracle',
-            'name': 'Oracle Linux Server',
-            'pretty_name': 'Oracle Linux Server 7.5',
-            'version': '7.5',
-            'pretty_version': '7.5',
-            'best_version': '7.5',
-            'major_version': '7',
-            'minor_version': '5'
+            "id": "oracle",
+            "name": "Oracle Linux Server",
+            "pretty_name": "Oracle Linux Server 7.5",
+            "version": "7.5",
+            "pretty_version": "7.5",
+            "best_version": "7.5",
+            "major_version": "7",
+            "minor_version": "5",
         }
         self._test_outcome(desired_outcome)
 
         desired_info = {
-            'id': 'oracle',
-            'name': 'Oracle Linux Server',
-            'version_id': '7.5',
+            "id": "oracle",
+            "name": "Oracle Linux Server",
+            "version_id": "7.5",
         }
-        distro_info = self._test_release_file_info(
-            'oracle-release', desired_info)
-        assert 'codename' not in distro_info
+        distro_info = self._test_release_file_info("oracle-release", desired_info)
+        assert "codename" not in distro_info
 
     def test_raspbian7_release(self):
         desired_outcome = {
-            'id': 'raspbian',
-            'name': 'Raspbian GNU/Linux',
-            'pretty_name': 'Raspbian GNU/Linux 7 (wheezy)',
-            'version': '7',
-            'pretty_version': '7 (wheezy)',
-            'best_version': '7',
-            'like': 'debian',
-            'codename': 'wheezy',
-            'major_version': '7',
+            "id": "raspbian",
+            "name": "Raspbian GNU/Linux",
+            "pretty_name": "Raspbian GNU/Linux 7 (wheezy)",
+            "version": "7",
+            "pretty_version": "7 (wheezy)",
+            "best_version": "7",
+            "like": "debian",
+            "codename": "wheezy",
+            "major_version": "7",
         }
         self._test_outcome(desired_outcome)
         self._test_non_existing_release_file()
 
     def test_raspbian8_release(self):
         desired_outcome = {
-            'id': 'raspbian',
-            'name': 'Raspbian GNU/Linux',
-            'pretty_name': 'Raspbian GNU/Linux 8 (jessie)',
-            'version': '8',
-            'pretty_version': '8 (jessie)',
-            'best_version': '8',
-            'like': 'debian',
-            'codename': 'jessie',
-            'major_version': '8',
+            "id": "raspbian",
+            "name": "Raspbian GNU/Linux",
+            "pretty_name": "Raspbian GNU/Linux 8 (jessie)",
+            "version": "8",
+            "pretty_version": "8 (jessie)",
+            "best_version": "8",
+            "like": "debian",
+            "codename": "jessie",
+            "major_version": "8",
         }
         self._test_outcome(desired_outcome)
         self._test_non_existing_release_file()
 
     def test_rhel5_release(self):
         desired_outcome = {
-            'id': 'rhel',
-            'name': 'Red Hat Enterprise Linux Server',
-            'pretty_name': 'Red Hat Enterprise Linux Server 5.11 (Tikanga)',
-            'version': '5.11',
-            'pretty_version': '5.11 (Tikanga)',
-            'best_version': '5.11',
-            'codename': 'Tikanga',
-            'major_version': '5',
-            'minor_version': '11'
+            "id": "rhel",
+            "name": "Red Hat Enterprise Linux Server",
+            "pretty_name": "Red Hat Enterprise Linux Server 5.11 (Tikanga)",
+            "version": "5.11",
+            "pretty_version": "5.11 (Tikanga)",
+            "best_version": "5.11",
+            "codename": "Tikanga",
+            "major_version": "5",
+            "minor_version": "11",
         }
         self._test_outcome(desired_outcome)
 
         desired_info = {
-            'id': 'redhat',
-            'name': 'Red Hat Enterprise Linux Server',
-            'version_id': '5.11',
-            'codename': 'Tikanga'
+            "id": "redhat",
+            "name": "Red Hat Enterprise Linux Server",
+            "version_id": "5.11",
+            "codename": "Tikanga",
         }
-        self._test_release_file_info('redhat-release', desired_info)
+        self._test_release_file_info("redhat-release", desired_info)
 
     def test_rhel6_release(self):
         desired_outcome = {
-            'id': 'rhel',
-            'name': 'Red Hat Enterprise Linux Server',
-            'pretty_name': 'Red Hat Enterprise Linux Server 6.5 (Santiago)',
-            'version': '6.5',
-            'pretty_version': '6.5 (Santiago)',
-            'best_version': '6.5',
-            'codename': 'Santiago',
-            'major_version': '6',
-            'minor_version': '5'
+            "id": "rhel",
+            "name": "Red Hat Enterprise Linux Server",
+            "pretty_name": "Red Hat Enterprise Linux Server 6.5 (Santiago)",
+            "version": "6.5",
+            "pretty_version": "6.5 (Santiago)",
+            "best_version": "6.5",
+            "codename": "Santiago",
+            "major_version": "6",
+            "minor_version": "5",
         }
         self._test_outcome(desired_outcome)
 
         desired_info = {
-            'id': 'redhat',
-            'name': 'Red Hat Enterprise Linux Server',
-            'version_id': '6.5',
-            'codename': 'Santiago'
+            "id": "redhat",
+            "name": "Red Hat Enterprise Linux Server",
+            "version_id": "6.5",
+            "codename": "Santiago",
         }
-        self._test_release_file_info('redhat-release', desired_info)
+        self._test_release_file_info("redhat-release", desired_info)
 
     def test_rhel7_release(self):
         desired_outcome = {
-            'id': 'rhel',
-            'name': 'Red Hat Enterprise Linux Server',
-            'pretty_name': 'Red Hat Enterprise Linux Server 7.0 (Maipo)',
-            'version': '7.0',
-            'pretty_version': '7.0 (Maipo)',
-            'best_version': '7.0',
-            'like': 'fedora',
-            'codename': 'Maipo',
-            'major_version': '7',
-            'minor_version': '0'
+            "id": "rhel",
+            "name": "Red Hat Enterprise Linux Server",
+            "pretty_name": "Red Hat Enterprise Linux Server 7.0 (Maipo)",
+            "version": "7.0",
+            "pretty_version": "7.0 (Maipo)",
+            "best_version": "7.0",
+            "like": "fedora",
+            "codename": "Maipo",
+            "major_version": "7",
+            "minor_version": "0",
         }
         self._test_outcome(desired_outcome)
 
         desired_info = {
-            'id': 'redhat',
-            'name': 'Red Hat Enterprise Linux Server',
-            'version_id': '7.0',
-            'codename': 'Maipo'
+            "id": "redhat",
+            "name": "Red Hat Enterprise Linux Server",
+            "version_id": "7.0",
+            "codename": "Maipo",
         }
-        self._test_release_file_info('redhat-release', desired_info)
+        self._test_release_file_info("redhat-release", desired_info)
 
     def test_slackware14_release(self):
         desired_outcome = {
-            'id': 'slackware',
-            'name': 'Slackware',
-            'pretty_name': 'Slackware 14.1',
-            'version': '14.1',
-            'pretty_version': '14.1',
-            'best_version': '14.1',
-            'major_version': '14',
-            'minor_version': '1'
+            "id": "slackware",
+            "name": "Slackware",
+            "pretty_name": "Slackware 14.1",
+            "version": "14.1",
+            "pretty_version": "14.1",
+            "best_version": "14.1",
+            "major_version": "14",
+            "minor_version": "1",
         }
         self._test_outcome(desired_outcome)
 
         desired_info = {
-            'id': 'slackware',
-            'name': 'Slackware',
-            'version_id': '14.1',
+            "id": "slackware",
+            "name": "Slackware",
+            "version_id": "14.1",
         }
-        distro_info = self._test_release_file_info(
-            'slackware-version', desired_info)
-        assert 'codename' not in distro_info
+        distro_info = self._test_release_file_info("slackware-version", desired_info)
+        assert "codename" not in distro_info
 
     def test_sles12_release(self):
         desired_outcome = {
-            'id': 'sles',
-            'name': 'SLES',
-            'pretty_name': 'SUSE Linux Enterprise Server 12 SP1',
-            'version': '12.1',
-            'pretty_version': '12.1 (n/a)',
-            'best_version': '12.1',
-            'codename': 'n/a',
-            'major_version': '12',
-            'minor_version': '1'
+            "id": "sles",
+            "name": "SLES",
+            "pretty_name": "SUSE Linux Enterprise Server 12 SP1",
+            "version": "12.1",
+            "pretty_version": "12.1 (n/a)",
+            "best_version": "12.1",
+            "codename": "n/a",
+            "major_version": "12",
+            "minor_version": "1",
         }
         self._test_outcome(desired_outcome)
 
         desired_info = {
-            'id': 'SuSE',
-            'name': 'SUSE Linux Enterprise Server',
-            'version_id': '12',
-            'codename': 's390x'
+            "id": "SuSE",
+            "name": "SUSE Linux Enterprise Server",
+            "version_id": "12",
+            "codename": "s390x",
         }
-        self._test_release_file_info('SuSE-release', desired_info)
+        self._test_release_file_info("SuSE-release", desired_info)
 
     def test_ubuntu14_release(self):
         desired_outcome = {
-            'id': 'ubuntu',
-            'name': 'Ubuntu',
-            'pretty_name': 'Ubuntu 14.04.3 LTS',
-            'version': '14.04',
-            'pretty_version': '14.04 (Trusty Tahr)',
-            'best_version': '14.04.3',
-            'like': 'debian',
-            'codename': 'Trusty Tahr',
-            'major_version': '14',
-            'minor_version': '04'
+            "id": "ubuntu",
+            "name": "Ubuntu",
+            "pretty_name": "Ubuntu 14.04.3 LTS",
+            "version": "14.04",
+            "pretty_version": "14.04 (Trusty Tahr)",
+            "best_version": "14.04.3",
+            "like": "debian",
+            "codename": "Trusty Tahr",
+            "major_version": "14",
+            "minor_version": "04",
         }
         self._test_outcome(desired_outcome)
 
@@ -1504,16 +1512,16 @@ class TestOverall(DistroTestCase):
 
     def test_ubuntu16_release(self):
         desired_outcome = {
-            'id': 'ubuntu',
-            'name': 'Ubuntu',
-            'pretty_name': 'Ubuntu 16.04.1 LTS',
-            'version': '16.04',
-            'pretty_version': '16.04 (xenial)',
-            'best_version': '16.04.1',
-            'like': 'debian',
-            'codename': 'xenial',
-            'major_version': '16',
-            'minor_version': '04'
+            "id": "ubuntu",
+            "name": "Ubuntu",
+            "pretty_name": "Ubuntu 16.04.1 LTS",
+            "version": "16.04",
+            "pretty_version": "16.04 (xenial)",
+            "best_version": "16.04.1",
+            "like": "debian",
+            "codename": "xenial",
+            "major_version": "16",
+            "minor_version": "04",
         }
         self._test_outcome(desired_outcome)
 
@@ -1524,15 +1532,15 @@ class TestOverall(DistroTestCase):
 
     def test_amazon2016_release(self):
         desired_outcome = {
-            'id': 'amzn',
-            'name': 'Amazon Linux AMI',
-            'pretty_name': 'Amazon Linux AMI 2016.03',
-            'version': '2016.03',
-            'pretty_version': '2016.03',
-            'best_version': '2016.03',
-            'like': 'rhel fedora',
-            'major_version': '2016',
-            'minor_version': '03'
+            "id": "amzn",
+            "name": "Amazon Linux AMI",
+            "pretty_name": "Amazon Linux AMI 2016.03",
+            "version": "2016.03",
+            "pretty_version": "2016.03",
+            "best_version": "2016.03",
+            "like": "rhel fedora",
+            "major_version": "2016",
+            "minor_version": "03",
         }
         self._test_outcome(desired_outcome)
 
@@ -1544,159 +1552,158 @@ class TestOverall(DistroTestCase):
 
     def test_scientific6_release(self):
         desired_outcome = {
-            'id': 'rhel',
-            'name': 'Scientific Linux',
-            'pretty_name': 'Scientific Linux 6.4 (Carbon)',
-            'version': '6.4',
-            'pretty_version': '6.4 (Carbon)',
-            'best_version': '6.4',
-            'codename': 'Carbon',
-            'major_version': '6',
-            'minor_version': '4',
-
+            "id": "rhel",
+            "name": "Scientific Linux",
+            "pretty_name": "Scientific Linux 6.4 (Carbon)",
+            "version": "6.4",
+            "pretty_version": "6.4 (Carbon)",
+            "best_version": "6.4",
+            "codename": "Carbon",
+            "major_version": "6",
+            "minor_version": "4",
         }
         self._test_outcome(desired_outcome)
 
         desired_info = {
-            'id': 'redhat',
-            'name': 'Scientific Linux',
-            'version_id': '6.4',
-            'codename': 'Carbon'
+            "id": "redhat",
+            "name": "Scientific Linux",
+            "version_id": "6.4",
+            "codename": "Carbon",
         }
-        self._test_release_file_info('redhat-release', desired_info)
+        self._test_release_file_info("redhat-release", desired_info)
 
     def test_scientific7_release(self):
         desired_outcome = {
-            'id': 'rhel',
-            'name': 'Scientific Linux',
-            'pretty_name': 'Scientific Linux 7.2 (Nitrogen)',
-            'version': '7.2',
-            'pretty_version': '7.2 (Nitrogen)',
-            'best_version': '7.2',
-            'like': 'fedora',
-            'codename': 'Nitrogen',
-            'major_version': '7',
-            'minor_version': '2',
+            "id": "rhel",
+            "name": "Scientific Linux",
+            "pretty_name": "Scientific Linux 7.2 (Nitrogen)",
+            "version": "7.2",
+            "pretty_version": "7.2 (Nitrogen)",
+            "best_version": "7.2",
+            "like": "fedora",
+            "codename": "Nitrogen",
+            "major_version": "7",
+            "minor_version": "2",
         }
         self._test_outcome(desired_outcome)
 
         desired_info = {
-            'id': 'redhat',
-            'name': 'Scientific Linux',
-            'version_id': '7.2',
-            'codename': 'Nitrogen'
+            "id": "redhat",
+            "name": "Scientific Linux",
+            "version_id": "7.2",
+            "codename": "Nitrogen",
         }
-        self._test_release_file_info('redhat-release', desired_info)
+        self._test_release_file_info("redhat-release", desired_info)
 
     def test_gentoo_release(self):
         desired_outcome = {
-            'id': 'gentoo',
-            'name': 'Gentoo',
-            'pretty_name': 'Gentoo/Linux',
-            'version': '2.2',
-            'pretty_version': '2.2',
-            'best_version': '2.2',
-            'major_version': '2',
-            'minor_version': '2',
+            "id": "gentoo",
+            "name": "Gentoo",
+            "pretty_name": "Gentoo/Linux",
+            "version": "2.2",
+            "pretty_version": "2.2",
+            "best_version": "2.2",
+            "major_version": "2",
+            "minor_version": "2",
         }
         self._test_outcome(desired_outcome)
 
         desired_info = {
-            'id': 'gentoo',
-            'name': 'Gentoo Base System',
-            'version_id': '2.2',
+            "id": "gentoo",
+            "name": "Gentoo Base System",
+            "version_id": "2.2",
         }
-        self._test_release_file_info('gentoo-release', desired_info)
+        self._test_release_file_info("gentoo-release", desired_info)
 
     def test_openelec6_release(self):
         desired_outcome = {
-            'id': 'openelec',
-            'name': 'OpenELEC',
-            'pretty_name': 'OpenELEC (official) - Version: 6.0.3',
-            'version': '6.0',
-            'pretty_version': '6.0',
-            'best_version': '6.0.3',
-            'major_version': '6',
-            'minor_version': '0',
+            "id": "openelec",
+            "name": "OpenELEC",
+            "pretty_name": "OpenELEC (official) - Version: 6.0.3",
+            "version": "6.0",
+            "pretty_version": "6.0",
+            "best_version": "6.0.3",
+            "major_version": "6",
+            "minor_version": "0",
         }
         self._test_outcome(desired_outcome)
 
     def test_mandriva2011_release(self):
         desired_outcome = {
-            'id': 'mandrivalinux',
-            'name': 'MandrivaLinux',
-            'pretty_name': 'Mandriva Linux 2011.0',
-            'version': '2011.0',
-            'pretty_version': '2011.0 (turtle)',
-            'best_version': '2011.0',
-            'major_version': '2011',
-            'minor_version': '0',
-            'codename': 'turtle'
+            "id": "mandrivalinux",
+            "name": "MandrivaLinux",
+            "pretty_name": "Mandriva Linux 2011.0",
+            "version": "2011.0",
+            "pretty_version": "2011.0 (turtle)",
+            "best_version": "2011.0",
+            "major_version": "2011",
+            "minor_version": "0",
+            "codename": "turtle",
         }
         self._test_outcome(desired_outcome)
 
         desired_info = {
-            'id': 'mandrake',
-            'name': 'Mandriva Linux',
-            'version_id': '2011.0',
+            "id": "mandrake",
+            "name": "Mandriva Linux",
+            "version_id": "2011.0",
         }
-        self._test_release_file_info('mandrake-release', desired_info)
+        self._test_release_file_info("mandrake-release", desired_info)
 
     def test_cloudlinux5_release(self):
         # Uses redhat-release only to get information.
         # The id of 'rhel' can only be fixed with issue #109.
         desired_outcome = {
-            'id': 'cloudlinux',
-            'codename': 'Vladislav Volkov',
-            'name': 'CloudLinux Server',
-            'pretty_name': 'CloudLinux Server 5.11 (Vladislav Volkov)',
-            'version': '5.11',
-            'pretty_version': '5.11 (Vladislav Volkov)',
-            'best_version': '5.11',
-            'major_version': '5',
-            'minor_version': '11'
+            "id": "cloudlinux",
+            "codename": "Vladislav Volkov",
+            "name": "CloudLinux Server",
+            "pretty_name": "CloudLinux Server 5.11 (Vladislav Volkov)",
+            "version": "5.11",
+            "pretty_version": "5.11 (Vladislav Volkov)",
+            "best_version": "5.11",
+            "major_version": "5",
+            "minor_version": "11",
         }
         self._test_outcome(desired_outcome)
 
     def test_cloudlinux6_release(self):
         # Same as above, only has redhat-release.
         desired_outcome = {
-            'id': 'cloudlinux',
-            'codename': 'Oleg Makarov',
-            'name': 'CloudLinux Server',
-            'pretty_name': 'CloudLinux Server 6.8 (Oleg Makarov)',
-            'version': '6.8',
-            'pretty_version': '6.8 (Oleg Makarov)',
-            'best_version': '6.8',
-            'major_version': '6',
-            'minor_version': '8'
+            "id": "cloudlinux",
+            "codename": "Oleg Makarov",
+            "name": "CloudLinux Server",
+            "pretty_name": "CloudLinux Server 6.8 (Oleg Makarov)",
+            "version": "6.8",
+            "pretty_version": "6.8 (Oleg Makarov)",
+            "best_version": "6.8",
+            "major_version": "6",
+            "minor_version": "8",
         }
         self._test_outcome(desired_outcome)
 
     def test_cloudlinux7_release(self):
         desired_outcome = {
-            'id': 'cloudlinux',
-            'codename': 'Yury Malyshev',
-            'name': 'CloudLinux',
-            'pretty_name': 'CloudLinux 7.3 (Yury Malyshev)',
-            'like': 'rhel fedora centos',
-            'version': '7.3',
-            'pretty_version': '7.3 (Yury Malyshev)',
-            'best_version': '7.3',
-            'major_version': '7',
-            'minor_version': '3'
+            "id": "cloudlinux",
+            "codename": "Yury Malyshev",
+            "name": "CloudLinux",
+            "pretty_name": "CloudLinux 7.3 (Yury Malyshev)",
+            "like": "rhel fedora centos",
+            "version": "7.3",
+            "pretty_version": "7.3 (Yury Malyshev)",
+            "best_version": "7.3",
+            "major_version": "7",
+            "minor_version": "3",
         }
         self._test_outcome(desired_outcome)
 
 
-def _bad_os_listdir(path='.'):
-    """ This function is used by TestOverallWithEtcNotReadable to simulate
+def _bad_os_listdir(path="."):
+    """This function is used by TestOverallWithEtcNotReadable to simulate
     a folder that cannot be called with os.listdir() but files are still
-    readable. Forces distro to guess which *-release files are available. """
+    readable. Forces distro to guess which *-release files are available."""
     raise OSError()
 
 
-@pytest.mark.skipif(not IS_LINUX, reason='Irrelevant on non-linux')
+@pytest.mark.skipif(not IS_LINUX, reason="Irrelevant on non-linux")
 class TestOverallWithEtcNotReadable(TestOverall):
     def setup_method(self, test_method):
         self._old_listdir = os.listdir
@@ -1709,7 +1716,7 @@ class TestOverallWithEtcNotReadable(TestOverall):
             os.listdir = self._old_listdir
 
 
-@pytest.mark.skipif(not IS_LINUX, reason='Irrelevant on non-linux')
+@pytest.mark.skipif(not IS_LINUX, reason="Irrelevant on non-linux")
 class TestGetAttr(DistroTestCase):
     """Test the consistency between the results of
     `{source}_release_attr()` and `{source}_release_info()` for all
@@ -1728,85 +1735,74 @@ class TestGetAttr(DistroTestCase):
                     print("distro: {0}, key: {1}".format(dist, key))
 
     def test_os_release_attr(self):
-        self._test_attr('os_release_info', 'os_release_attr')
+        self._test_attr("os_release_info", "os_release_attr")
 
     def test_lsb_release_attr(self):
-        self._test_attr('lsb_release_info', 'lsb_release_attr')
+        self._test_attr("lsb_release_info", "lsb_release_attr")
 
     def test_distro_release_attr(self):
-        self._test_attr('distro_release_info', 'distro_release_attr')
+        self._test_attr("distro_release_info", "distro_release_attr")
 
 
-@pytest.mark.skipif(not IS_LINUX, reason='Irrelevant on non-linux')
+@pytest.mark.skipif(not IS_LINUX, reason="Irrelevant on non-linux")
 class TestInfo(DistroTestCase):
-
     def setup_method(self, test_method):
         super(TestInfo, self).setup_method(test_method)
         self.ubuntu14_os_release = os.path.join(
-            DISTROS_DIR, 'ubuntu14', 'etc', 'os-release')
+            DISTROS_DIR, "ubuntu14", "etc", "os-release"
+        )
 
     def test_info(self):
         _distro = distro.LinuxDistribution(
             include_lsb=False,
             os_release_file=self.ubuntu14_os_release,
-            distro_release_file='path-to-non-existing-file')
+            distro_release_file="path-to-non-existing-file",
+        )
 
         desired_info = {
-            'id': 'ubuntu',
-            'version': '14.04',
-            'like': 'debian',
-            'version_parts': {
-                'major': '14',
-                'minor': '04',
-                'build_number': ''
-            },
-            'codename': 'Trusty Tahr'
+            "id": "ubuntu",
+            "version": "14.04",
+            "like": "debian",
+            "version_parts": {"major": "14", "minor": "04", "build_number": ""},
+            "codename": "Trusty Tahr",
         }
 
         info = _distro.info()
         assert info == desired_info
 
-        desired_info_diff = {
-            'version': '14.04 (Trusty Tahr)'
-        }
+        desired_info_diff = {"version": "14.04 (Trusty Tahr)"}
         desired_info.update(desired_info_diff)
         info = _distro.info(pretty=True)
         assert info == desired_info
 
         desired_info_diff = {
-            'version': '14.04.3',
-            'version_parts': {
-                'major': '14',
-                'minor': '04',
-                'build_number': '3'
-            }
+            "version": "14.04.3",
+            "version_parts": {"major": "14", "minor": "04", "build_number": "3"},
         }
         desired_info.update(desired_info_diff)
         info = _distro.info(best=True)
         assert info == desired_info
 
-        desired_info_diff = {
-            'version': '14.04.3 (Trusty Tahr)'
-        }
+        desired_info_diff = {"version": "14.04.3 (Trusty Tahr)"}
         desired_info.update(desired_info_diff)
         info = _distro.info(pretty=True, best=True)
         assert info == desired_info
 
     def test_none(self):
-
         def _test_none(info):
-            assert info['id'] == ''
-            assert info['version'] == ''
-            assert info['like'] == ''
-            assert info['version_parts']['major'] == ''
-            assert info['version_parts']['minor'] == ''
-            assert info['version_parts']['build_number'] == ''
-            assert info['codename'] == ''
+            assert info["id"] == ""
+            assert info["version"] == ""
+            assert info["like"] == ""
+            assert info["version_parts"]["major"] == ""
+            assert info["version_parts"]["minor"] == ""
+            assert info["version_parts"]["build_number"] == ""
+            assert info["codename"] == ""
 
         _distro = distro.LinuxDistribution(
             include_lsb=False,
-            os_release_file='path-to-non-existing-file',
-            distro_release_file='path-to-non-existing-file')
+            os_release_file="path-to-non-existing-file",
+            distro_release_file="path-to-non-existing-file",
+        )
 
         info = _distro.info()
         _test_none(info)
@@ -1822,34 +1818,34 @@ class TestInfo(DistroTestCase):
 
     def test_linux_distribution(self):
         _distro = distro.LinuxDistribution(
-            include_lsb=False,
-            os_release_file=self.ubuntu14_os_release)
+            include_lsb=False, os_release_file=self.ubuntu14_os_release
+        )
         i = _distro.linux_distribution()
-        assert i == ('Ubuntu', '14.04', 'Trusty Tahr')
+        assert i == ("Ubuntu", "14.04", "Trusty Tahr")
 
     def test_linux_distribution_full_false(self):
         _distro = distro.LinuxDistribution(
-            include_lsb=False,
-            os_release_file=self.ubuntu14_os_release)
+            include_lsb=False, os_release_file=self.ubuntu14_os_release
+        )
         i = _distro.linux_distribution(full_distribution_name=False)
-        assert i == ('ubuntu', '14.04', 'Trusty Tahr')
+        assert i == ("ubuntu", "14.04", "Trusty Tahr")
 
     def test_all(self):
         """Test info() by comparing its results with the results of specific
         consolidated accessor functions.
         """
+
         def _test_all(info, best=False, pretty=False):
-            assert info['id'] == _distro.id()
-            assert info['version'] == _distro.version(pretty=pretty, best=best)
-            assert info['version_parts']['major'] == \
-                _distro.major_version(best=best)
-            assert info['version_parts']['minor'] == \
-                _distro.minor_version(best=best)
-            assert info['version_parts']['build_number'] == \
-                _distro.build_number(best=best)
-            assert info['like'] == _distro.like()
-            assert info['codename'] == _distro.codename()
-            assert len(info['version_parts']) == 3
+            assert info["id"] == _distro.id()
+            assert info["version"] == _distro.version(pretty=pretty, best=best)
+            assert info["version_parts"]["major"] == _distro.major_version(best=best)
+            assert info["version_parts"]["minor"] == _distro.minor_version(best=best)
+            assert info["version_parts"]["build_number"] == _distro.build_number(
+                best=best
+            )
+            assert info["like"] == _distro.like()
+            assert info["codename"] == _distro.codename()
+            assert len(info["version_parts"]) == 3
             assert len(info) == 5
 
         for dist in DISTROS:
@@ -1870,23 +1866,23 @@ class TestInfo(DistroTestCase):
             _test_all(info, pretty=True, best=True)
 
 
-@pytest.mark.skipif(not IS_LINUX, reason='Irrelevant on non-linux')
+@pytest.mark.skipif(not IS_LINUX, reason="Irrelevant on non-linux")
 class TestOSReleaseParsing:
-    """Test the parsing of os-release files.
-    """
+    """Test the parsing of os-release files."""
 
     def setup_method(self, test_method):
         self.distro = distro.LinuxDistribution(
-            include_lsb=False,
-            os_release_file=None,
-            distro_release_file=None)
+            include_lsb=False, os_release_file=None, distro_release_file=None
+        )
 
         self.distro.debug = True
 
     def _get_props(self, input):
-        return self.distro._parse_os_release_content(StringIO(
-            input,
-        ))
+        return self.distro._parse_os_release_content(
+            StringIO(
+                input,
+            )
+        )
 
     def _test_zero_length_props(self, input):
         props = self._get_props(input)
@@ -1894,148 +1890,147 @@ class TestOSReleaseParsing:
 
     def _test_empty_value(self, input):
         props = self._get_props(input)
-        assert props.get('key', None) == ''
+        assert props.get("key", None) == ""
 
     def _test_parsed_value(self, input):
         props = self._get_props(input)
-        assert props.get('key', None) == 'value'
+        assert props.get("key", None) == "value"
 
     def test_kv_01_empty_file(self):
-        self._test_zero_length_props('')
+        self._test_zero_length_props("")
 
     def test_kv_02_empty_line(self):
-        self._test_zero_length_props('\n')
+        self._test_zero_length_props("\n")
 
     def test_kv_03_empty_line_with_crlf(self):
-        self._test_zero_length_props('\r\n')
+        self._test_zero_length_props("\r\n")
 
     def test_kv_04_empty_line_with_just_cr(self):
-        self._test_zero_length_props('\r')
+        self._test_zero_length_props("\r")
 
     def test_kv_05_comment(self):
-        self._test_zero_length_props('# KEY=value\n')
+        self._test_zero_length_props("# KEY=value\n")
 
     def test_kv_06_empty_value(self):
-        self._test_empty_value('KEY=\n')
+        self._test_empty_value("KEY=\n")
 
     def test_kv_07_empty_value_single_quoted(self):
-        self._test_empty_value('KEY=\'\'\n')
+        self._test_empty_value("KEY=''\n")
 
     def test_kv_08_empty_value_double_quoted(self):
         self._test_empty_value('KEY=""\n')
 
     def test_kv_09_word(self):
-        self._test_parsed_value('KEY=value\n')
+        self._test_parsed_value("KEY=value\n")
 
     def test_kv_10_word_no_newline(self):
-        self._test_parsed_value('KEY=value')
+        self._test_parsed_value("KEY=value")
 
     def test_kv_11_word_with_crlf(self):
-        self._test_parsed_value('KEY=value\r\n')
+        self._test_parsed_value("KEY=value\r\n")
 
     def test_kv_12_word_with_just_cr(self):
-        self._test_parsed_value('KEY=value\r')
+        self._test_parsed_value("KEY=value\r")
 
     def test_kv_13_word_with_multi_blanks(self):
-        self._test_empty_value('KEY=  cmd   \n')
+        self._test_empty_value("KEY=  cmd   \n")
         # Note: Without quotes, this assigns the empty string, and 'cmd' is
         # a separate token that is being ignored (it would be a command
         # in the shell).
 
     def test_kv_14_unquoted_words(self):
-        self._test_parsed_value('KEY=value cmd\n')
+        self._test_parsed_value("KEY=value cmd\n")
 
     def test_kv_15_double_quoted_words(self):
         props = self._get_props('KEY="a simple value" cmd\n')
-        assert props.get('key', None) == 'a simple value'
+        assert props.get("key", None) == "a simple value"
 
     def test_kv_16_double_quoted_words_with_multi_blanks(self):
         props = self._get_props('KEY=" a  simple   value "\n')
-        assert props.get('key', None) == ' a  simple   value '
+        assert props.get("key", None) == " a  simple   value "
 
     def test_kv_17_double_quoted_word_with_single_quote(self):
         props = self._get_props('KEY="it\'s value"\n')
-        assert props.get('key', None) == 'it\'s value'
+        assert props.get("key", None) == "it's value"
 
     def test_kv_18_double_quoted_word_with_double_quote(self):
         props = self._get_props('KEY="a \\"bold\\" move"\n')
-        assert props.get('key', None) == 'a "bold" move'
+        assert props.get("key", None) == 'a "bold" move'
 
     def test_kv_19_single_quoted_words(self):
-        props = self._get_props('KEY=\'a simple value\'\n')
-        assert props.get('key', None) == 'a simple value'
+        props = self._get_props("KEY='a simple value'\n")
+        assert props.get("key", None) == "a simple value"
 
     def test_kv_20_single_quoted_words_with_multi_blanks(self):
-        props = self._get_props('KEY=\' a  simple   value \'\n')
-        assert props.get('key', None) == ' a  simple   value '
+        props = self._get_props("KEY=' a  simple   value '\n")
+        assert props.get("key", None) == " a  simple   value "
 
     def test_kv_21_single_quoted_word_with_double_quote(self):
-        props = self._get_props('KEY=\'a "bold" move\'\n')
-        assert props.get('key', None) == 'a "bold" move'
+        props = self._get_props("KEY='a \"bold\" move'\n")
+        assert props.get("key", None) == 'a "bold" move'
 
     def test_kv_22_quoted_unicode_wordchar(self):
         # "wordchar" means it is in the shlex.wordchars variable.
         props = self._get_props(u'KEY="wordchar: \u00CA (E accent grave)"\n')
-        assert props.get('key', None) == u'wordchar: \u00CA (E accent grave)'
+        assert props.get("key", None) == u"wordchar: \u00CA (E accent grave)"
 
     def test_kv_23_quoted_unicode_non_wordchar(self):
         # "non-wordchar" means it is not in the shlex.wordchars variable.
         props = self._get_props(
-            u'KEY="non-wordchar: \u00A1 (inverted exclamation mark)"\n')
-        assert (props.get('key', None) ==
-                u'non-wordchar: \u00A1 (inverted exclamation mark)')
+            u'KEY="non-wordchar: \u00A1 (inverted exclamation mark)"\n'
+        )
+        assert (
+            props.get("key", None)
+            == u"non-wordchar: \u00A1 (inverted exclamation mark)"
+        )
 
     def test_kv_24_double_quoted_entire_single_quoted_word(self):
-        props = self._get_props('KEY="\'value\'"\n')
-        assert props.get('key', None) == "'value'"
+        props = self._get_props("KEY=\"'value'\"\n")
+        assert props.get("key", None) == "'value'"
 
     def test_kv_25_single_quoted_entire_double_quoted_word(self):
-        props = self._get_props('KEY=\'"value"\'\n')
-        assert props.get('key', None) == '"value"'
+        props = self._get_props("KEY='\"value\"'\n")
+        assert props.get("key", None) == '"value"'
 
     def test_kv_26_double_quoted_multiline(self):
-        props = self.distro._parse_os_release_content(StringIO(
-            'KEY="a multi\n'
-            'line value"\n'
-        ))
-        assert props.get('key', None) == 'a multi\nline value'
+        props = self.distro._parse_os_release_content(
+            StringIO('KEY="a multi\n' 'line value"\n')
+        )
+        assert props.get("key", None) == "a multi\nline value"
         # TODO: Find out why the result is not 'a multi line value'
 
     def test_kv_27_double_quoted_multiline_2(self):
-        props = self._get_props('KEY=\' a  simple   value \'\n')
-        props = self.distro._parse_os_release_content(StringIO(
-            'KEY="a multi\n'
-            'line=value"\n'
-        ))
-        assert props.get('key', None) == 'a multi\nline=value'
+        props = self._get_props("KEY=' a  simple   value '\n")
+        props = self.distro._parse_os_release_content(
+            StringIO('KEY="a multi\n' 'line=value"\n')
+        )
+        assert props.get("key", None) == "a multi\nline=value"
         # TODO: Find out why the result is not 'a multi line=value'
 
     def test_kv_28_double_quoted_word_with_equal(self):
         props = self._get_props('KEY="var=value"\n')
-        assert props.get('key', None) == 'var=value'
+        assert props.get("key", None) == "var=value"
 
     def test_kv_29_single_quoted_word_with_equal(self):
-        props = self._get_props('KEY=\'var=value\'\n')
-        assert props.get('key', None) == 'var=value'
+        props = self._get_props("KEY='var=value'\n")
+        assert props.get("key", None) == "var=value"
 
     def test_kx_01(self):
-        props = self.distro._parse_os_release_content(StringIO(
-            'KEY1=value1\n'
-            'KEY2="value  2"\n'
-        ))
-        assert props.get('key1', None) == 'value1'
-        assert props.get('key2', None) == 'value  2'
+        props = self.distro._parse_os_release_content(
+            StringIO("KEY1=value1\n" 'KEY2="value  2"\n')
+        )
+        assert props.get("key1", None) == "value1"
+        assert props.get("key2", None) == "value  2"
 
     def test_kx_02(self):
-        props = self.distro._parse_os_release_content(StringIO(
-            '# KEY1=value1\n'
-            'KEY2="value  2"\n'
-        ))
-        assert props.get('key1', None) is None
-        assert props.get('key2', None) == 'value  2'
+        props = self.distro._parse_os_release_content(
+            StringIO("# KEY1=value1\n" 'KEY2="value  2"\n')
+        )
+        assert props.get("key1", None) is None
+        assert props.get("key2", None) == "value  2"
 
 
-@pytest.mark.skipif(not IS_LINUX, reason='Irrelevant on non-linux')
+@pytest.mark.skipif(not IS_LINUX, reason="Irrelevant on non-linux")
 class TestGlobal:
     """Test the global module-level functions, and default values of their
     arguments.
@@ -2059,114 +2054,108 @@ class TestGlobal:
             function_result = getattr(distro, function)(**kwargs)
             assert method_result == function_result
 
-        kwargs = {'full_distribution_name': True}
-        _test_consistency('linux_distribution', kwargs)
-        kwargs = {'full_distribution_name': False}
-        _test_consistency('linux_distribution', kwargs)
+        kwargs = {"full_distribution_name": True}
+        _test_consistency("linux_distribution", kwargs)
+        kwargs = {"full_distribution_name": False}
+        _test_consistency("linux_distribution", kwargs)
 
-        kwargs = {'pretty': False}
-        _test_consistency('name', kwargs)
-        _test_consistency('version', kwargs)
-        _test_consistency('info', kwargs)
+        kwargs = {"pretty": False}
+        _test_consistency("name", kwargs)
+        _test_consistency("version", kwargs)
+        _test_consistency("info", kwargs)
 
-        kwargs = {'pretty': True}
-        _test_consistency('name', kwargs)
-        _test_consistency('version', kwargs)
-        _test_consistency('info', kwargs)
+        kwargs = {"pretty": True}
+        _test_consistency("name", kwargs)
+        _test_consistency("version", kwargs)
+        _test_consistency("info", kwargs)
 
-        kwargs = {'best': False}
-        _test_consistency('version', kwargs)
-        _test_consistency('version_parts', kwargs)
-        _test_consistency('major_version', kwargs)
-        _test_consistency('minor_version', kwargs)
-        _test_consistency('build_number', kwargs)
-        _test_consistency('info', kwargs)
+        kwargs = {"best": False}
+        _test_consistency("version", kwargs)
+        _test_consistency("version_parts", kwargs)
+        _test_consistency("major_version", kwargs)
+        _test_consistency("minor_version", kwargs)
+        _test_consistency("build_number", kwargs)
+        _test_consistency("info", kwargs)
 
-        kwargs = {'best': True}
-        _test_consistency('version', kwargs)
-        _test_consistency('version_parts', kwargs)
-        _test_consistency('major_version', kwargs)
-        _test_consistency('minor_version', kwargs)
-        _test_consistency('build_number', kwargs)
-        _test_consistency('info', kwargs)
+        kwargs = {"best": True}
+        _test_consistency("version", kwargs)
+        _test_consistency("version_parts", kwargs)
+        _test_consistency("major_version", kwargs)
+        _test_consistency("minor_version", kwargs)
+        _test_consistency("build_number", kwargs)
+        _test_consistency("info", kwargs)
 
-        _test_consistency('id')
-        _test_consistency('like')
-        _test_consistency('codename')
-        _test_consistency('info')
+        _test_consistency("id")
+        _test_consistency("like")
+        _test_consistency("codename")
+        _test_consistency("info")
 
-        _test_consistency('os_release_info')
-        _test_consistency('lsb_release_info')
-        _test_consistency('distro_release_info')
-        _test_consistency('uname_info')
+        _test_consistency("os_release_info")
+        _test_consistency("lsb_release_info")
+        _test_consistency("distro_release_info")
+        _test_consistency("uname_info")
 
         os_release_keys = [
-            'name',
-            'version',
-            'id',
-            'id_like',
-            'pretty_name',
-            'version_id',
-            'codename',
+            "name",
+            "version",
+            "id",
+            "id_like",
+            "pretty_name",
+            "version_id",
+            "codename",
         ]
         for key in os_release_keys:
-            _test_consistency('os_release_attr', {'attribute': key})
+            _test_consistency("os_release_attr", {"attribute": key})
 
         lsb_release_keys = [
-            'distributor_id',
-            'description',
-            'release',
-            'codename',
+            "distributor_id",
+            "description",
+            "release",
+            "codename",
         ]
         for key in lsb_release_keys:
-            _test_consistency('lsb_release_attr', {'attribute': key})
+            _test_consistency("lsb_release_attr", {"attribute": key})
 
         distro_release_keys = [
-            'id',
-            'name',
-            'version_id',
-            'codename',
+            "id",
+            "name",
+            "version_id",
+            "codename",
         ]
         for key in distro_release_keys:
-            _test_consistency('distro_release_attr', {'attribute': key})
+            _test_consistency("distro_release_attr", {"attribute": key})
 
-        uname_keys = [
-            'id',
-            'name',
-            'release'
-        ]
+        uname_keys = ["id", "name", "release"]
         for key in uname_keys:
-            _test_consistency('uname_attr', {'attribute': key})
+            _test_consistency("uname_attr", {"attribute": key})
 
 
-@pytest.mark.skipif(not IS_LINUX, reason='Irrelevant on non-linux')
+@pytest.mark.skipif(not IS_LINUX, reason="Irrelevant on non-linux")
 class TestRepr:
-    """Test the __repr__() method.
-    """
+    """Test the __repr__() method."""
 
     def test_repr(self):
         # We test that the class name and the names of all instance attributes
         # show up in the repr() string.
-        repr_str = repr(distro._distro)
+        repr_str = repr(distro._DISTRO)
         assert "LinuxDistribution" in repr_str
         for attr in MODULE_DISTRO.__dict__.keys():
-            if attr in ('root_dir', 'etc_dir'):
+            if attr in ("root_dir", "etc_dir"):
                 continue
-            assert attr + '=' in repr_str
+            assert attr + "=" in repr_str
 
 
-@pytest.mark.skipif(not IS_LINUX, reason='Irrelevant on non-linux')
+@pytest.mark.skipif(not IS_LINUX, reason="Irrelevant on non-linux")
 class TestToStr:
-    """Test the _to_str() method.
-    """
+    """Test the _to_str() method."""
 
     def test_to_str(self):
-        ret = distro.LinuxDistribution._to_str(b'bytes')
+        ret = distro.LinuxDistribution._to_str(b"bytes")
         assert isinstance(ret, str)
-        assert ret == 'bytes'
+        assert ret == "bytes"
 
-        ret = distro.LinuxDistribution._to_str(u'bytes')
+        ret = distro.LinuxDistribution._to_str(u"bytes")
         assert isinstance(ret, str)
 
-        ret = distro.LinuxDistribution._to_str('bytes')
+        ret = distro.LinuxDistribution._to_str("bytes")
         assert isinstance(ret, str)

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@
 
 [tox]
 minversion = 1.7.2
-envlist = flake8, py3flake8, py27, py3{4,5,6,7,8}, pypy{2,3}
+envlist = pylint27, pylint38, py27, py3{4,5,6,7,8}, pypy{2,3}
 skip_missing_interpreters = true
 
 [testenv]
@@ -31,12 +31,10 @@ commands= pytest --cov-report term-missing --cov distro tests -v
 basepython = {env:PYTHON:}\python.exe
 passenv= ProgramFiles LOGNAME USER LNAME USERNAME HOME USERPROFILE
 
-[testenv:flake8]
+[testenv:pylint27]
 basepython = python2.7
-deps = flake8
-commands = flake8 distro.py
+commands = pylint distro.py
 
-[testenv:py3flake8]
+[testenv:pylint38]
 basepython = python3.8
-deps = flake8
-commands = flake8 distro.py
+commands = pylint distro.py

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@
 
 [tox]
 minversion = 1.7.2
-envlist = pylint27, pylint38, py27, py3{4,5,6,7,8}, pypy{2,3}
+envlist = pylint38, py27, py3{4,5,6,7,8}, pypy{2,3}
 skip_missing_interpreters = true
 
 [testenv]
@@ -30,10 +30,6 @@ deps =
 commands= pytest --cov-report term-missing --cov distro tests -v
 basepython = {env:PYTHON:}\python.exe
 passenv= ProgramFiles LOGNAME USER LNAME USERNAME HOME USERPROFILE
-
-[testenv:pylint27]
-basepython = python2.7
-commands = pylint distro.py
 
 [testenv:pylint38]
 basepython = python3.8


### PR DESCRIPTION
* Add `.pylintrc`
* Add pylint config to CI workflow and tox.
* Fix linting issues. For more info, see the commit message for https://github.com/python-distro/distro/commit/85c52b85c7ca8ec02770d04c90eb9cd4527b410a
* Remove py27 linting. It's EOL. Not sure if that makes sense right now, given that we test on 27. However, I'm not sure we should lint for it. Thoughts?