### PR TITLE
Drop support for EOL Pythons

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,13 +28,10 @@ jobs:
     strategy:
       matrix:
         python:
-          - 2.7
-          - 3.5
           - 3.6
           - 3.7
           - 3.8
           - 3.9
-          - pypy2
           - pypy3
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 21.6b0
     hooks:
       - id: black
-        args: ["--target-version", "py27"]
+        args: ["--target-version", "py36"]
   - repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
     hooks:

--- a/README.md
+++ b/README.md
@@ -92,9 +92,8 @@ namely from these data sources (from high to low precedence):
 
 ## Python and Distribution Support
 
-`distro` is supported and tested on Python 2.7, 3.4+ and PyPy and on
-any distribution that provides one or more of the data sources
-covered.
+`distro` is supported and tested on Python 3.6+ and PyPy and on any
+distribution that provides one or more of the data sources covered.
 
 This package is tested with test data that mimics the exact behavior of the data sources of [a number of Linux distributions](https://github.com/python-distro/distro/tree/master/tests/resources/distros).
 

--- a/distro.py
+++ b/distro.py
@@ -36,35 +36,39 @@ import shlex
 import subprocess
 import sys
 import warnings
-from typing import TYPE_CHECKING
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Optional,
+    Sequence,
+    TextIO,
+    Tuple,
+    Type,
+)
+
+try:
+    from typing import TypedDict
+except ImportError:
+    # Python 3.7
+    TypedDict = dict
 
 __version__ = "1.6.0"
 
-if TYPE_CHECKING:  # pragma: nocover
-    from typing import (
-        Any,
-        Callable,
-        Dict,
-        Iterable,
-        Optional,
-        Sequence,
-        TextIO,
-        Tuple,
-        Type,
-        TypedDict,
-    )
 
-    class VersionDict(TypedDict):
-        major: str
-        minor: str
-        build_number: str
+class VersionDict(TypedDict):
+    major: str
+    minor: str
+    build_number: str
 
-    class InfoDict(TypedDict):
-        id: str
-        version: str
-        version_parts: VersionDict
-        like: str
-        codename: str
+
+class InfoDict(TypedDict):
+    id: str
+    version: str
+    version_parts: VersionDict
+    like: str
+    codename: str
 
 
 _UNIXCONFDIR = os.environ.get("UNIXCONFDIR", "/etc")
@@ -128,8 +132,7 @@ _DISTRO_RELEASE_IGNORE_BASENAMES = (
 )
 
 
-def linux_distribution(full_distribution_name=True):
-    # type: (bool) -> Tuple[str, str, str]
+def linux_distribution(full_distribution_name: bool = True) -> Tuple[str, str, str]:
     """
     .. deprecated:: 1.6.0
 
@@ -171,8 +174,7 @@ def linux_distribution(full_distribution_name=True):
     return _distro.linux_distribution(full_distribution_name)
 
 
-def id():
-    # type: () -> str
+def id() -> str:
     """
     Return the distro ID of the current distribution, as a
     machine-readable string.
@@ -251,8 +253,7 @@ def id():
     return _distro.id()
 
 
-def name(pretty=False):
-    # type: (bool) -> str
+def name(pretty: bool = False) -> str:
     """
     Return the name of the current OS distribution, as a human-readable
     string.
@@ -291,8 +292,7 @@ def name(pretty=False):
     return _distro.name(pretty)
 
 
-def version(pretty=False, best=False):
-    # type: (bool, bool) -> str
+def version(pretty: bool = False, best: bool = False) -> str:
     """
     Return the version of the current OS distribution, as a human-readable
     string.
@@ -336,8 +336,7 @@ def version(pretty=False, best=False):
     return _distro.version(pretty, best)
 
 
-def version_parts(best=False):
-    # type: (bool) -> Tuple[str, str, str]
+def version_parts(best: bool = False) -> Tuple[str, str, str]:
     """
     Return the version of the current OS distribution as a tuple
     ``(major, minor, build_number)`` with items as follows:
@@ -354,8 +353,7 @@ def version_parts(best=False):
     return _distro.version_parts(best)
 
 
-def major_version(best=False):
-    # type: (bool) -> str
+def major_version(best: bool = False) -> str:
     """
     Return the major version of the current OS distribution, as a string,
     if provided.
@@ -368,8 +366,7 @@ def major_version(best=False):
     return _distro.major_version(best)
 
 
-def minor_version(best=False):
-    # type: (bool) -> str
+def minor_version(best: bool = False) -> str:
     """
     Return the minor version of the current OS distribution, as a string,
     if provided.
@@ -382,8 +379,7 @@ def minor_version(best=False):
     return _distro.minor_version(best)
 
 
-def build_number(best=False):
-    # type: (bool) -> str
+def build_number(best: bool = False) -> str:
     """
     Return the build number of the current OS distribution, as a string,
     if provided.
@@ -396,8 +392,7 @@ def build_number(best=False):
     return _distro.build_number(best)
 
 
-def like():
-    # type: () -> str
+def like() -> str:
     """
     Return a space-separated list of distro IDs of distributions that are
     closely related to the current OS distribution in regards to packaging
@@ -414,8 +409,7 @@ def like():
     return _distro.like()
 
 
-def codename():
-    # type: () -> str
+def codename() -> str:
     """
     Return the codename for the release of the current OS distribution,
     as a string.
@@ -439,8 +433,7 @@ def codename():
     return _distro.codename()
 
 
-def info(pretty=False, best=False):
-    # type: (bool, bool) -> InfoDict
+def info(pretty: bool = False, best: bool = False) -> InfoDict:
     """
     Return certain machine-readable information items about the current OS
     distribution in a dictionary, as shown in the following example:
@@ -484,8 +477,7 @@ def info(pretty=False, best=False):
     return _distro.info(pretty, best)
 
 
-def os_release_info():
-    # type: () -> Dict[str, str]
+def os_release_info() -> Dict[str, str]:
     """
     Return a dictionary containing key-value pairs for the information items
     from the os-release file data source of the current OS distribution.
@@ -495,8 +487,7 @@ def os_release_info():
     return _distro.os_release_info()
 
 
-def lsb_release_info():
-    # type: () -> Dict[str, str]
+def lsb_release_info() -> Dict[str, str]:
     """
     Return a dictionary containing key-value pairs for the information items
     from the lsb_release command data source of the current OS distribution.
@@ -507,8 +498,7 @@ def lsb_release_info():
     return _distro.lsb_release_info()
 
 
-def distro_release_info():
-    # type: () -> Dict[str, str]
+def distro_release_info() -> Dict[str, str]:
     """
     Return a dictionary containing key-value pairs for the information items
     from the distro release file data source of the current OS distribution.
@@ -518,8 +508,7 @@ def distro_release_info():
     return _distro.distro_release_info()
 
 
-def uname_info():
-    # type: () -> Dict[str, str]
+def uname_info() -> Dict[str, str]:
     """
     Return a dictionary containing key-value pairs for the information items
     from the distro release file data source of the current OS distribution.
@@ -527,8 +516,7 @@ def uname_info():
     return _distro.uname_info()
 
 
-def os_release_attr(attribute):
-    # type: (str) -> str
+def os_release_attr(attribute: str) -> str:
     """
     Return a single named information item from the os-release file data source
     of the current OS distribution.
@@ -547,8 +535,7 @@ def os_release_attr(attribute):
     return _distro.os_release_attr(attribute)
 
 
-def lsb_release_attr(attribute):
-    # type: (str) -> str
+def lsb_release_attr(attribute: str) -> str:
     """
     Return a single named information item from the lsb_release command output
     data source of the current OS distribution.
@@ -568,8 +555,7 @@ def lsb_release_attr(attribute):
     return _distro.lsb_release_attr(attribute)
 
 
-def distro_release_attr(attribute):
-    # type: (str) -> str
+def distro_release_attr(attribute: str) -> str:
     """
     Return a single named information item from the distro release file
     data source of the current OS distribution.
@@ -588,8 +574,7 @@ def distro_release_attr(attribute):
     return _distro.distro_release_attr(attribute)
 
 
-def uname_attr(attribute):
-    # type: (str) -> str
+def uname_attr(attribute: str) -> str:
     """
     Return a single named information item from the distro release file
     data source of the current OS distribution.
@@ -616,13 +601,11 @@ except ImportError:
         will not re-call the property.
         """
 
-        def __init__(self, f):
-            # type: (Callable[[Any], Any]) -> None
+        def __init__(self, f: Callable[[Any], Any]) -> None:
             self._fname = f.__name__
             self._f = f
 
-        def __get__(self, obj, owner):
-            # type: (Any, Type[Any]) -> Any
+        def __get__(self, obj: Any, owner: Type[Any]) -> Any:
             assert obj is not None, f"call {self._fname} on an instance"
             ret = obj.__dict__[self._fname] = self._f(obj)
             return ret
@@ -648,13 +631,12 @@ class LinuxDistribution:
 
     def __init__(
         self,
-        include_lsb=True,
-        os_release_file="",
-        distro_release_file="",
-        include_uname=True,
-        root_dir=None,
-    ):
-        # type: (bool, str, str, bool, Optional[str]) -> None
+        include_lsb: bool = True,
+        os_release_file: str = "",
+        distro_release_file: str = "",
+        include_uname: bool = True,
+        root_dir: Optional[str] = None,
+    ) -> None:
         """
         The initialization method of this class gathers information from the
         available data sources, and stores that in private instance attributes.
@@ -752,8 +734,7 @@ class LinuxDistribution:
         self.include_lsb = include_lsb
         self.include_uname = include_uname
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         """Return repr of all info"""
         return (
             "LinuxDistribution("
@@ -767,8 +748,9 @@ class LinuxDistribution:
             "_uname_info={self._uname_info!r})".format(self=self)
         )
 
-    def linux_distribution(self, full_distribution_name=True):
-        # type: (bool) -> Tuple[str, str, str]
+    def linux_distribution(
+        self, full_distribution_name: bool = True
+    ) -> Tuple[str, str, str]:
         """
         Return information about the OS distribution that is compatible
         with Python's :func:`platform.linux_distribution`, supporting a subset
@@ -782,15 +764,13 @@ class LinuxDistribution:
             self.codename(),
         )
 
-    def id(self):
-        # type: () -> str
+    def id(self) -> str:
         """Return the distro ID of the OS distribution, as a string.
 
         For details, see :func:`distro.id`.
         """
 
-        def normalize(distro_id, table):
-            # type: (str, Dict[str, str]) -> str
+        def normalize(distro_id: str, table: Dict[str, str]) -> str:
             distro_id = distro_id.lower().replace(" ", "_")
             return table.get(distro_id, distro_id)
 
@@ -812,8 +792,7 @@ class LinuxDistribution:
 
         return ""
 
-    def name(self, pretty=False):
-        # type: (bool) -> str
+    def name(self, pretty: bool = False) -> str:
         """
         Return the name of the OS distribution, as a string.
 
@@ -836,8 +815,7 @@ class LinuxDistribution:
                     name = name + " " + version
         return name or ""
 
-    def version(self, pretty=False, best=False):
-        # type: (bool, bool) -> str
+    def version(self, pretty: bool = False, best: bool = False) -> str:
         """
         Return the version of the OS distribution, as a string.
 
@@ -873,8 +851,7 @@ class LinuxDistribution:
             version = f"{version} ({self.codename()})"
         return version
 
-    def version_parts(self, best=False):
-        # type: (bool) -> Tuple[str, str, str]
+    def version_parts(self, best: bool = False) -> Tuple[str, str, str]:
         """
         Return the version of the OS distribution, as a tuple of version
         numbers.
@@ -890,8 +867,7 @@ class LinuxDistribution:
                 return major, minor or "", build_number or ""
         return "", "", ""
 
-    def major_version(self, best=False):
-        # type: (bool) -> str
+    def major_version(self, best: bool = False) -> str:
         """
         Return the major version number of the current distribution.
 
@@ -899,8 +875,7 @@ class LinuxDistribution:
         """
         return self.version_parts(best)[0]
 
-    def minor_version(self, best=False):
-        # type: (bool) -> str
+    def minor_version(self, best: bool = False) -> str:
         """
         Return the minor version number of the current distribution.
 
@@ -908,8 +883,7 @@ class LinuxDistribution:
         """
         return self.version_parts(best)[1]
 
-    def build_number(self, best=False):
-        # type: (bool) -> str
+    def build_number(self, best: bool = False) -> str:
         """
         Return the build number of the current distribution.
 
@@ -917,8 +891,7 @@ class LinuxDistribution:
         """
         return self.version_parts(best)[2]
 
-    def like(self):
-        # type: () -> str
+    def like(self) -> str:
         """
         Return the IDs of distributions that are like the OS distribution.
 
@@ -926,8 +899,7 @@ class LinuxDistribution:
         """
         return self.os_release_attr("id_like") or ""
 
-    def codename(self):
-        # type: () -> str
+    def codename(self) -> str:
         """
         Return the codename of the OS distribution.
 
@@ -944,8 +916,7 @@ class LinuxDistribution:
                 or ""
             )
 
-    def info(self, pretty=False, best=False):
-        # type: (bool, bool) -> InfoDict
+    def info(self, pretty: bool = False, best: bool = False) -> InfoDict:
         """
         Return certain machine-readable information about the OS
         distribution.
@@ -964,8 +935,7 @@ class LinuxDistribution:
             codename=self.codename(),
         )
 
-    def os_release_info(self):
-        # type: () -> Dict[str, str]
+    def os_release_info(self) -> Dict[str, str]:
         """
         Return a dictionary containing key-value pairs for the information
         items from the os-release file data source of the OS distribution.
@@ -974,8 +944,7 @@ class LinuxDistribution:
         """
         return self._os_release_info
 
-    def lsb_release_info(self):
-        # type: () -> Dict[str, str]
+    def lsb_release_info(self) -> Dict[str, str]:
         """
         Return a dictionary containing key-value pairs for the information
         items from the lsb_release command data source of the OS
@@ -985,8 +954,7 @@ class LinuxDistribution:
         """
         return self._lsb_release_info
 
-    def distro_release_info(self):
-        # type: () -> Dict[str, str]
+    def distro_release_info(self) -> Dict[str, str]:
         """
         Return a dictionary containing key-value pairs for the information
         items from the distro release file data source of the OS
@@ -996,8 +964,7 @@ class LinuxDistribution:
         """
         return self._distro_release_info
 
-    def uname_info(self):
-        # type: () -> Dict[str, str]
+    def uname_info(self) -> Dict[str, str]:
         """
         Return a dictionary containing key-value pairs for the information
         items from the uname command data source of the OS distribution.
@@ -1006,8 +973,7 @@ class LinuxDistribution:
         """
         return self._uname_info
 
-    def os_release_attr(self, attribute):
-        # type: (str) -> str
+    def os_release_attr(self, attribute: str) -> str:
         """
         Return a single named information item from the os-release file data
         source of the OS distribution.
@@ -1016,8 +982,7 @@ class LinuxDistribution:
         """
         return self._os_release_info.get(attribute, "")
 
-    def lsb_release_attr(self, attribute):
-        # type: (str) -> str
+    def lsb_release_attr(self, attribute: str) -> str:
         """
         Return a single named information item from the lsb_release command
         output data source of the OS distribution.
@@ -1026,8 +991,7 @@ class LinuxDistribution:
         """
         return self._lsb_release_info.get(attribute, "")
 
-    def distro_release_attr(self, attribute):
-        # type: (str) -> str
+    def distro_release_attr(self, attribute: str) -> str:
         """
         Return a single named information item from the distro release file
         data source of the OS distribution.
@@ -1036,8 +1000,7 @@ class LinuxDistribution:
         """
         return self._distro_release_info.get(attribute, "")
 
-    def uname_attr(self, attribute):
-        # type: (str) -> str
+    def uname_attr(self, attribute: str) -> str:
         """
         Return a single named information item from the uname command
         output data source of the OS distribution.
@@ -1047,8 +1010,7 @@ class LinuxDistribution:
         return self._uname_info.get(attribute, "")
 
     @cached_property
-    def _os_release_info(self):
-        # type: () -> Dict[str, str]
+    def _os_release_info(self) -> Dict[str, str]:
         """
         Get the information items from the specified os-release file.
 
@@ -1061,8 +1023,7 @@ class LinuxDistribution:
         return {}
 
     @staticmethod
-    def _parse_os_release_content(lines):
-        # type: (TextIO) -> Dict[str, str]
+    def _parse_os_release_content(lines: TextIO) -> Dict[str, str]:
         """
         Parse the lines of an os-release file.
 
@@ -1117,8 +1078,7 @@ class LinuxDistribution:
         return props
 
     @cached_property
-    def _lsb_release_info(self):
-        # type: () -> Dict[str, str]
+    def _lsb_release_info(self) -> Dict[str, str]:
         """
         Get the information items from the lsb_release command output.
 
@@ -1137,8 +1097,7 @@ class LinuxDistribution:
         return self._parse_lsb_release_content(content)
 
     @staticmethod
-    def _parse_lsb_release_content(lines):
-        # type: (Iterable[str]) -> Dict[str, str]
+    def _parse_lsb_release_content(lines: Iterable[str]) -> Dict[str, str]:
         """
         Parse the output of the lsb_release command.
 
@@ -1162,8 +1121,7 @@ class LinuxDistribution:
         return props
 
     @cached_property
-    def _uname_info(self):
-        # type: () -> Dict[str, str]
+    def _uname_info(self) -> Dict[str, str]:
         try:
             cmd = ("uname", "-rs")
             stdout = subprocess.check_output(cmd, stderr=subprocess.DEVNULL)
@@ -1173,8 +1131,7 @@ class LinuxDistribution:
         return self._parse_uname_content(content)
 
     @staticmethod
-    def _parse_uname_content(lines):
-        # type: (Sequence[str]) -> Dict[str, str]
+    def _parse_uname_content(lines: Sequence[str]) -> Dict[str, str]:
         props = {}
         match = re.search(r"^([^\s]+)\s+([\d\.]+)", lines[0].strip())
         if match:
@@ -1191,14 +1148,12 @@ class LinuxDistribution:
         return props
 
     @staticmethod
-    def _to_str(bytestring):
-        # type: (bytes) -> str
+    def _to_str(bytestring: bytes) -> str:
         encoding = sys.getfilesystemencoding()
         return bytestring.decode(encoding)
 
     @cached_property
-    def _distro_release_info(self):
-        # type: () -> Dict[str, str]
+    def _distro_release_info(self) -> Dict[str, str]:
         """
         Get the information items from the specified distro release file.
 
@@ -1265,8 +1220,7 @@ class LinuxDistribution:
                         return distro_info
             return {}
 
-    def _parse_distro_release_file(self, filepath):
-        # type: (str) -> Dict[str, str]
+    def _parse_distro_release_file(self, filepath: str) -> Dict[str, str]:
         """
         Parse a distro release file.
 
@@ -1289,8 +1243,7 @@ class LinuxDistribution:
             return {}
 
     @staticmethod
-    def _parse_distro_release_content(line):
-        # type: (str) -> Dict[str, str]
+    def _parse_distro_release_content(line: str) -> Dict[str, str]:
         """
         Parse a line from a distro release file.
 
@@ -1318,8 +1271,7 @@ class LinuxDistribution:
 _distro = LinuxDistribution()
 
 
-def main():
-    # type: () -> None
+def main() -> None:
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.DEBUG)
     logger.addHandler(logging.StreamHandler(sys.stdout))

--- a/distro.py
+++ b/distro.py
@@ -812,7 +812,7 @@ class LinuxDistribution:
                 name = self.distro_release_attr("name") or self.uname_attr("name")
                 version = self.version(pretty=True)
                 if version:
-                    name = name + " " + version
+                    name = f"{name} {version}"
         return name or ""
 
     def version(self, pretty: bool = False, best: bool = False) -> str:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,13 +19,13 @@ If you want to jump into the API description right away, read about the
 Compatibility
 =============
 
-The ``distro`` package is supported on Python 2.7, 3.4+ and PyPy, and on any
-Linux or BSD distribution that provides one or more of the `data sources`_ used
-by this package.
+The ``distro`` package is supported on Python 3.6+ and PyPy, and on any Linux
+or BSD distribution that provides one or more of the `data sources`_ used by
+this package.
 
-This package is tested on Python 2.7, 3.4+ and PyPy, with test data that
-mimics the exact behavior of the data sources of
-`a number of Linux distributions <https://github.com/python-distro/distro/tree/master/tests/resources/distros>`_.
+This package is tested on Python 3.6+ and PyPy, with test data that mimics the
+exact behavior of the data sources of `a number of Linux distributions
+<https://github.com/python-distro/distro/tree/master/tests/resources/distros>`_.
 
 If you want to add test data for more distributions, please
 create an issue in the `distro issue tracker`_

--- a/query_local_distro.py
+++ b/query_local_distro.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 from pprint import pformat
 
 import distro
@@ -31,15 +29,15 @@ print("lsb_release_info:")
 pprint(distro.lsb_release_info())
 print("distro_release_info:")
 pprint(distro.distro_release_info())
-print("id: {0}".format(distro.id()))
-print("name: {0}".format(distro.name()))
-print("name_pretty: {0}".format(distro.name(True)))
-print("version: {0}".format(distro.version()))
-print("version_pretty: {0}".format(distro.version(True)))
-print("like: {0}".format(distro.like()))
-print("codename: {0}".format(distro.codename()))
-print("linux_distribution_full: {0}".format(distro.linux_distribution()))
-print("linux_distribution: {0}".format(distro.linux_distribution(False)))
-print("major_version: {0}".format(distro.major_version()))
-print("minor_version: {0}".format(distro.minor_version()))
-print("build_number: {0}".format(distro.build_number()))
+print(f"id: {distro.id()}")
+print(f"name: {distro.name()}")
+print(f"name_pretty: {distro.name(True)}")
+print(f"version: {distro.version()}")
+print(f"version_pretty: {distro.version(True)}")
+print(f"like: {distro.like()}")
+print(f"codename: {distro.codename()}")
+print(f"linux_distribution_full: {distro.linux_distribution()}")
+print(f"linux_distribution: {distro.linux_distribution(False)}")
+print(f"major_version: {distro.major_version()}")
+print(f"minor_version: {distro.minor_version()}")
+print(f"build_number: {distro.build_number()}")

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,6 @@ classifiers =
     Operating System :: POSIX :: BSD :: OpenBSD
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.4
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -32,6 +30,7 @@ classifiers =
 
 [options]
 py_modules = distro
+python_requires = >=3.6
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,9 +19,8 @@ classifiers =
     Operating System :: POSIX :: BSD :: FreeBSD
     Operating System :: POSIX :: BSD :: NetBSD
     Operating System :: POSIX :: BSD :: OpenBSD
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
@@ -37,9 +36,6 @@ py_modules = distro
 [options.entry_points]
 console_scripts =
     distro = distro:main
-
-[bdist_wheel]
-universal = 1
 
 [flake8]
 max-line-length = 88

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -71,11 +71,11 @@ class TestCli:
 
     def test_cli(self):
         command = [sys.executable, "-m", "distro"]
-        desired_output = "Name: " + distro.name(pretty=True)
+        desired_output = f"Name: {distro.name(pretty=True)}"
         distro_version = distro.version(pretty=True)
         distro_codename = distro.codename()
-        desired_output += "\n" + "Version: " + distro_version
-        desired_output += "\n" + "Codename: " + distro_codename
+        desired_output += f"\nVersion: {distro_version}"
+        desired_output += f"\nCodename: {distro_codename}"
         desired_output += "\n"
         assert self._run(command) == desired_output
 
@@ -736,7 +736,7 @@ class TestDistroRelease:
             DISTROS_DIR,
             distro_name + version,
             "etc",
-            "{}-{}".format(release_file_id, release_file_suffix),
+            f"{release_file_id}-{release_file_suffix}",
         )
         self.distro = distro.LinuxDistribution(
             include_lsb=False,
@@ -2128,4 +2128,4 @@ class TestRepr:
         for attr in MODULE_DISTRO.__dict__.keys():
             if attr in ("root_dir", "etc_dir", "usr_lib_dir"):
                 continue
-            assert attr + "=" in repr_str
+            assert f"{attr}=" in repr_str

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@
 
 [tox]
 minversion = 1.9
-envlist = lint, py27, py3{4,5,6,7,8,9}, pypy{2,3}
+envlist = lint, py{36,37,38,39,py3}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Python 2.7 and 3.4, and 3.5 are end of life. They are no longer
receiving bug fixes, including for security issues. For additional
details on support Python versions, see:

Supported: https://devguide.python.org/#status-of-python-branches
EOL: https://devguide.python.org/devcycle/#end-of-life-branches

Removing support for EOL Pythons will reduce testing and maintenance
resources while allowing the library to move towards a modern Python 3
style.