### PR TITLE
Introduce isort for consistent formatting of imports

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,34 +6,20 @@ on:
 
 jobs:
   lint:
-    name: ${{ matrix.toxenv }}
+    name: lint
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        include:
-          - python: 2.7
-            toxenv: flake8
-          - python: 3.x
-            toxenv: py3flake8
-          - python: 3.x
-            toxenv: isort
-          - python: 3.x
-            toxenv: mypy
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.python }}
+      - name: Set up Python
         uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python }}
 
       - name: Install tox
         run: python -m pip install tox
 
       - name: Run tox
-        run: tox -e ${{ matrix.toxenv }}
+        run: tox -e lint
 
   test:
     name: ${{ matrix.toxenv }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,8 @@ jobs:
           - python: 3.x
             toxenv: py3flake8
           - python: 3.x
+            toxenv: isort
+          - python: 3.x
             toxenv: mypy
 
     steps:

--- a/distro.py
+++ b/distro.py
@@ -28,14 +28,14 @@ is needed. See `Python issue 1322 <https://bugs.python.org/issue1322>`_ for
 more information.
 """
 
+import argparse
+import json
+import logging
 import os
 import re
-import sys
-import json
 import shlex
-import logging
-import argparse
 import subprocess
+import sys
 
 # Use `if False` to avoid an ImportError on Python 2. After dropping Python 2
 # support, can use typing.TYPE_CHECKING instead. See:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,9 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
 import re
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ universal = 1
 
 [flake8]
 max-line-length = 88
+
+[isort]
+profile = black

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import codecs
+import os
+
 from setuptools import setup
 
 # The following version is parsed by other parts of this package.

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -13,17 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import ast
+import os
 import subprocess
+import sys
+
 try:
     from StringIO import StringIO  # Python 2.x
 except ImportError:
     from io import StringIO  # Python 3.x
 
 import pytest
-
 
 BASE = os.path.abspath(os.path.dirname(__file__))
 RESOURCES = os.path.join(BASE, 'resources')

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@
 
 [tox]
 minversion = 1.7.2
-envlist = flake8, py3flake8, isort, mypy, py27, py3{4,5,6,7,8,9}, pypy{2,3}
+envlist = lint, py27, py3{4,5,6,7,8,9}, pypy{2,3}
 skip_missing_interpreters = true
 
 [testenv]
@@ -31,21 +31,12 @@ commands= pytest --cov-report term-missing --cov distro tests -v
 basepython = {env:PYTHON:}\python.exe
 passenv= ProgramFiles LOGNAME USER LNAME USERNAME HOME USERPROFILE
 
-[testenv:flake8]
-basepython = python2.7
-deps = flake8
-commands = flake8
-
-[testenv:py3flake8]
-basepython = python3
-deps = flake8
-commands = flake8
-
-[testenv:isort]
-deps = isort
-commands = isort --check --diff .
-
-[testenv:mypy]
-basepython = python3
-deps = mypy
-commands = mypy --strict distro.py
+[testenv:lint]
+deps =
+    flake8
+    isort
+    mypy
+commands =
+    flake8
+    isort --check --diff .
+    mypy --strict distro.py

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@
 
 [tox]
 minversion = 1.7.2
-envlist = flake8, py3flake8, mypy, py27, py3{4,5,6,7,8,9}, pypy{2,3}
+envlist = flake8, py3flake8, isort, mypy, py27, py3{4,5,6,7,8,9}, pypy{2,3}
 skip_missing_interpreters = true
 
 [testenv]
@@ -40,6 +40,10 @@ commands = flake8
 basepython = python3
 deps = flake8
 commands = flake8
+
+[testenv:isort]
+deps = isort
+commands = isort --check --diff .
 
 [testenv:mypy]
 basepython = python3


### PR DESCRIPTION
Using isort helps make the import order and code style consistent across
files and contributions. Let the tools and CI handle the details to
avoid friction during new contributions and review.

https://pycqa.github.io/isort/