### PR TITLE
Update comments regarding platform.linux_distribution deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ version information.
 
 It is the recommended replacement for Python's original
 [`platform.linux_distribution`](https://docs.python.org/3.7/library/platform.html#platform.linux_distribution)
-function (which will be removed in Python 3.8).
-It also provides much more functionality which isn't necessarily Python bound,
-like a command-line interface.
+function (removed in Python 3.8). It also provides much more functionality
+which isn't necessarily Python bound, like a command-line interface.
 
 Distro currently supports Linux and BSD based systems but [Windows and OS X support](https://github.com/python-distro/distro/issues/177) is also planned.
 
@@ -77,10 +76,9 @@ API, see the [latest API documentation](http://distro.readthedocs.org/en/latest/
 ## Background
 
 An alternative implementation became necessary because Python 3.5 deprecated
-this function, and Python 3.8 will remove it altogether.
-Its predecessor function `platform.dist` was already deprecated since
-Python 2.6 and will also be removed in Python 3.8.
-Still, there are many cases in which access to that information is needed.
+this function, and Python 3.8 removed it altogether. Its predecessor function
+`platform.dist` was already deprecated since Python 2.6 and removed in Python
+3.8. Still, there are many cases in which access to that information is needed.
 See [Python issue 1322](https://bugs.python.org/issue1322) for more
 information.
 

--- a/distro.py
+++ b/distro.py
@@ -20,12 +20,11 @@ machine-readable distro ID, or version information.
 It is the recommended replacement for Python's original
 :py:func:`platform.linux_distribution` function, but it provides much more
 functionality. An alternative implementation became necessary because Python
-3.5 deprecated this function, and Python 3.8 will remove it altogether.
-Its predecessor function :py:func:`platform.dist` was already
-deprecated since Python 2.6 and will also be removed in Python 3.8.
-Still, there are many cases in which access to OS distribution information
-is needed. See `Python issue 1322 <https://bugs.python.org/issue1322>`_ for
-more information.
+3.5 deprecated this function, and Python 3.8 removed it altogether. Its
+predecessor function :py:func:`platform.dist` was already deprecated since
+Python 2.6 and removed in Python 3.8. Still, there are many cases in which
+access to OS distribution information is needed. See `Python issue 1322
+<https://bugs.python.org/issue1322>`_ for more information.
 """
 
 import os


### PR DESCRIPTION
Python 3.8 release has since passed, changed the wording from future
tense to past tense.