### PR TITLE
Move `import json` to top of file per PEP8

### DIFF
--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import ast
+import json
 import os
 import subprocess
 import sys
@@ -93,7 +94,6 @@ class TestCli:
         assert desired_output == self._run(command)
 
     def test_cli_with_root_dir_as_json(self):
-        import json
         root_dir = os.path.join(RESOURCES, 'cli', 'fedora30')
         command = [sys.executable, '-m', 'distro', '-j', '--root-dir', root_dir]
         desired_output = {


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0008/#imports

> Imports are always put at the top of the file, just after any module
> comments and docstrings, and before module globals and constants.