### PR TITLE
Replace setup.py with declarative setup.cfg

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -36,6 +36,8 @@ import shlex
 import subprocess
 import sys
 
+__version__ = "1.5.0"
+
 # Use `if False` to avoid an ImportError on Python 2. After dropping Python 2
 # support, can use typing.TYPE_CHECKING instead. See:
 # https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,13 +13,14 @@
 # serve to show the default.
 
 import os
-import re
 import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath(".."))
+
+import distro  # noqa: E402
 
 # -- General configuration ------------------------------------------------
 
@@ -67,23 +68,9 @@ _short_description = u"Linux Distribution - a Linux OS platform information API"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-
-def parse_version():
-    with open("../setup.py", "r") as _fp:
-        _lines = _fp.readlines()
-        for _line in _lines:
-            m = re.match(r'^package_version *= *[\'"](.+)[\'"].*$', _line)
-            if m:
-                break
-        if m:
-            return m.group(1)
-        else:
-            return "unknown"
-
-
 # The short X.Y version.
 # Note: We use the full version in both cases.
-version = parse_version()
+version = distro.__version__
 
 # The full version, including alpha/beta/rc tags.
 release = version

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,43 @@
+[metadata]
+name = distro
+version = attr: distro.__version__
+url = https://github.com/python-distro/distro
+author = Nir Cohen
+author_email = nir36g@gmail.com
+license = Apache License, Version 2.0
+platforms = All
+description= Distro - an OS platform information API
+long_description = file: README.md
+long_description_content_type = text/markdown
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    Intended Audience :: System Administrators
+    License :: OSI Approved :: Apache Software License
+    Operating System :: POSIX :: Linux
+    Operating System :: POSIX :: BSD
+    Operating System :: POSIX :: BSD :: FreeBSD
+    Operating System :: POSIX :: BSD :: NetBSD
+    Operating System :: POSIX :: BSD :: OpenBSD
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Topic :: Software Development :: Libraries :: Python Modules
+    Topic :: System :: Operating System
+
+[options]
+py_modules = distro
+
+[options.entry_points]
+console_scripts =
+    distro = distro:main
+
 [bdist_wheel]
 universal = 1
 

--- a/setup.py
+++ b/setup.py
@@ -12,56 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import codecs
-import os
-
 from setuptools import setup
 
-# The following version is parsed by other parts of this package.
-# Don't change the format of the line, or the variable name.
-package_version = "1.5.0"
-
-here = os.path.abspath(os.path.dirname(__file__))
-
-
-def read(*parts):
-    # intentionally *not* adding an encoding option to open
-    return codecs.open(os.path.join(here, *parts), "r").read()
-
-
-setup(
-    name="distro",
-    version=package_version,
-    url="https://github.com/python-distro/distro",
-    author="Nir Cohen",
-    author_email="nir36g@gmail.com",
-    license="Apache License, Version 2.0",
-    platforms="All",
-    description="Distro - an OS platform information API",
-    long_description=read("README.md"),
-    long_description_content_type="text/markdown",
-    py_modules=["distro"],
-    entry_points={"console_scripts": ["distro = distro:main"]},
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Intended Audience :: System Administrators",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: POSIX :: Linux",
-        "Operating System :: POSIX :: BSD",
-        "Operating System :: POSIX :: BSD :: FreeBSD",
-        "Operating System :: POSIX :: BSD :: NetBSD",
-        "Operating System :: POSIX :: BSD :: OpenBSD",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Topic :: System :: Operating System",
-    ],
-)
+setup()


### PR DESCRIPTION
Avoid mixing code with configuration.

Running setuptools no longer runs arbitrary custom code, it is all
driven through a key/value configuration file, setup.cfg.

This also simplifies other tools interaction. For example, the Sphinx
config no longer needs to parse source code (and hope the format hasn't
changed). Now, it can use the configparser library to pull values from
setup.cfg.