### PR TITLE
Add distro.__version__attribute

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -36,6 +36,17 @@ import shlex
 import subprocess
 import sys
 
+try:
+    import importlib.metadata
+
+    __version__ = importlib.metadata.version("distro")
+except ImportError:
+    # Python 3.7
+    import pkg_resources  # type: ignore
+
+    __version__ = pkg_resources.get_distribution("distro").version
+
+
 # Use `if False` to avoid an ImportError on Python 2. After dropping Python 2
 # support, can use typing.TYPE_CHECKING instead. See:
 # https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -16,6 +16,7 @@
 import ast
 import json
 import os
+import re
 import subprocess
 import sys
 
@@ -2132,3 +2133,8 @@ class TestToStr:
 
         ret = distro.LinuxDistribution._to_str("bytes")
         assert isinstance(ret, str)
+
+
+@pytest.mark.skipif(not IS_LINUX, reason="Irrelevant on non-linux")
+def test_version():
+    assert re.match(r"^\d+\.\d+\.\d+$", distro.__version__) is not None


### PR DESCRIPTION
Use the version supplied to setuptools as a single source of truth. On
newer Pythons, can use importlib.metadata to acquire the version.

https://docs.python.org/3/library/importlib.metadata.html

Fixes #265