### PR TITLE
Update platform.linux_distribution links to Python 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ API, see the [latest API documentation](http://distro.readthedocs.org/en/latest/
 
 An alternative implementation became necessary because Python 3.5 deprecated
 this function, and Python 3.8 removed it altogether. Its predecessor function
-`platform.dist` was already deprecated since Python 2.6 and removed in Python
-3.8. Still, there are many cases in which access to that information is needed.
-See [Python issue 1322](https://bugs.python.org/issue1322) for more
-information.
+[`platform.dist`](https://docs.python.org/3.7/library/platform.html#platform.dist)
+was already deprecated since Python 2.6 and removed in Python 3.8. Still, there
+are many cases in which access to that information is needed. See [Python issue
+1322](https://bugs.python.org/issue1322) for more information.
 
 The `distro` package implements a robust and inclusive way of retrieving the
 information about a distribution based on new standards and old methods,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -125,9 +125,11 @@ htmlhelp_basename = "distro_doc"
 # For documentation, see
 # http://www.sphinx-doc.org/en/stable/ext/intersphinx.html
 
-# Defines the prefixes for intersphinx links, and the targets they resolve
-# to. Example RST source for 'py' prefix:
+# Defines the prefixes for intersphinx links and the targets they resolve to.
+# Use Python 3.7 as that is the last version to include
+# platform.linux_distribution() and platform.dist(). Example RST source for
+# 'py' prefix:
 #     :py:func:`platform.dist`
-intersphinx_mapping = {"py": ("https://docs.python.org/3", None)}
+intersphinx_mapping = {"py": ("https://docs.python.org/3.7", None)}
 
 intersphinx_cache_limit = 5


### PR DESCRIPTION
As platform.linux_distribution() and platform.dist() were removed from
Python 3, the doc links no longer exist. For these deprecated functions,
use Python 3.7, the last version to include them.
