### PR TITLE
Fix several warnings when building the docs

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -1032,7 +1032,7 @@ class LinuxDistribution(object):
         Return a single named information item from the uname command
         output data source of the OS distribution.
 
-        For details, see :func:`distro.uname_release_attr`.
+        For details, see :func:`distro.uname_attr`.
         """
         return self._uname_info.get(attribute, "")
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,3 @@
-
 .. _distro official repo: https://github.com/python-distro/distro
 .. _distro issue tracker: https://github.com/python-distro/distro/issues
 .. _open issues on missing test data: https://github.com/python-distro/distro/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22>
@@ -20,9 +19,9 @@ If you want to jump into the API description right away, read about the
 Compatibility
 =============
 
-The ``distro`` package is supported on Python 2.7, 3.4+ and PyPy, and on
-any Linux or *BSD distribution that provides one or more of the `data sources`_
-used by this package.
+The ``distro`` package is supported on Python 2.7, 3.4+ and PyPy, and on any
+Linux or BSD distribution that provides one or more of the `data sources`_ used
+by this package.
 
 This package is tested on Python 2.7, 3.4+ and PyPy, with test data that
 mimics the exact behavior of the data sources of
@@ -54,7 +53,7 @@ namely from these data sources:
 
 * The `distro release file`_, if present.
 
-* The `uname command output`_, if present.
+* The ``uname`` command output, if present.
 
 
 Access to the information
@@ -81,12 +80,11 @@ distribution:
   will come from the distro release file (because it is not provided by the
   lsb_release command).
 
-  Examples: :func:`distro.id` for retrieving
-  the distro ID, or :func:`ld.info` to get the machine-readable part of the
-  information in a more aggregated way, or :func:`distro.linux_distribution` with
-  an interface that is compatible to the original
-  :py:func:`platform.linux_distribution` function, supporting a subset of its
-  parameters.
+  Examples: :func:`distro.id` for retrieving the distro ID, or
+  :func:`distro.info` to get the machine-readable part of the information in a
+  more aggregated way, or :func:`distro.linux_distribution` with an interface
+  that is compatible to the original :py:func:`platform.linux_distribution`
+  function, supporting a subset of its parameters.
 
 * `Single source accessor functions`_
 
@@ -148,9 +146,11 @@ accessor functions.
 .. autofunction:: distro.os_release_info
 .. autofunction:: distro.lsb_release_info
 .. autofunction:: distro.distro_release_info
+.. autofunction:: distro.uname_info
 .. autofunction:: distro.os_release_attr
 .. autofunction:: distro.lsb_release_attr
 .. autofunction:: distro.distro_release_attr
+.. autofunction:: distro.uname_attr
 
 LinuxDistribution class
 =======================
@@ -474,4 +474,3 @@ The following information items can be found in a distro release file
     version_id                       "42.1"
     codename                         "x86_64"
     ===============================  ==========================================
-


### PR DESCRIPTION
In index.rst, the word BSD had a single star. Remove it as the word
doesn't need emphasizing. Fixes warning:

    docs/index.rst:23: WARNING: Inline emphasis start-string without end-string.

The section "uname command output" doesn't exist, so remove the link.
Fixes warning:

    docs/index.rst:57: WARNING: Unknown target name: "uname command output".

In commit 7d30cf20c418e7af9aad08e9c6277c9c4a699f2b the name was changed
from "ld" to "distro". One mention in the docs was missed. Fixes the
warning:

    docs/index.rst:84: WARNING: py:func reference target not found: ld.info

The function distro.uname_info is undocumented. Other docs shouldn't
reference it. Fixes warning:

    distro.py:docstring of distro.LinuxDistribution.uname_info:4: WARNING: py:func reference target not found: distro.uname_info

The function uname_release_attr doesn't exist. It was probably intended
to be uname_attr. However, that function is undocumented and so should
also not be documented. Fixes warning:

    distro.py:docstring of distro.LinuxDistribution.uname_info:4: WARNING: py:func reference target not found: distro.uname_info