### PR TITLE
Add py.typed file to package for PEP-561 compliance

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Install tox
-        run: python -m pip install tox
+        run: python -m pip install --upgrade tox setuptools
 
       - name: Run tox
         run: tox -e py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,4 +17,4 @@ repos:
     hooks:
       - id: mypy
         args: ["--strict"]
-        files: ^distro\.py$
+        files: ^distro/.*\.py$

--- a/distro/__init__.py
+++ b/distro/__init__.py
@@ -1365,7 +1365,3 @@ def main():
         logger.info("Version: %s", distribution_version)
         distribution_codename = dist.codename()
         logger.info("Codename: %s", distribution_codename)
-
-
-if __name__ == "__main__":
-    main()

--- a/distro/__main__.py
+++ b/distro/__main__.py
@@ -1,0 +1,4 @@
+from . import main
+
+if __name__ == "__main__":
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,10 @@ classifiers =
     Topic :: System :: Operating System
 
 [options]
-py_modules = distro
+packages = distro
+
+[options.package_data]
+* = py.typed
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Per PEP-561, packages that include type information that can be consumed
by other libraries should distribute a py.typed file. This tells mypy
and other tools to use type information shipped with the library.

This requires moving distro from a single module file to a package so
that it can ship data files.

For details on PEP-561, see:
https://www.python.org/dev/peps/pep-0561/

For details on mypy using py.typed, see:
https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages