### PR TITLE
Enable Sphinx "nitpicky" mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ PACKAGENAME = distro
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS ?= -v
+SPHINXOPTS ?= -n -v
 SPHINXBUILD ?= sphinx-build
 SPHINXSOURCEDIR = docs
 SPHINXBUILDDIR = docs/_build


### PR DESCRIPTION
Helps catch additional doc errors such as missing references.

Can't yet enable the "turn warnings into errors" option as there remain
a few warnings:

    .../distro.py:docstring of distro.info:: WARNING: py:class reference target not found: InfoDict
    .../distro.py:docstring of distro.LinuxDistribution.info:: WARNING: py:class reference target not found: InfoDict