### PR TITLE
Release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,6 @@ RELEASE:
 * Moved repository from `nir0s/distro` to
   [`python-distro/distro`](https://github.com/python-distro/distro) on GitHub.
 
-TESTS:
-* Changed CI to use GitHub Actions [[#277](https://github.com/python-distro/distro/pull/277)]
-
-DOCS:
-* Pinned intersphinx links to Python 3.7 [[#297](https://github.com/python-distro/distro/pull/297)]
-
-
 ## 1.5.0 (2020.3.30)
 
 BACKWARD COMPATIBILITY:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## 1.6.0 (2021.7.14)
+
+BACKWARDS COMPATIBILITY:
+* Deprecated the `distro.linux_distribution()` function. Use
+  `distro.id()`, `distro.version()` and `distro.name()` instead
+  [[#296](https://github.com/python-distro/distro/pull/296)]
+* Deprecated Python 2.7, 3.4 and 3.5 support. Further releases
+  will only support Python 3.6+ 
+
+ENHANCEMENTS:
+* Added type hints to `distro` module [[#269](https://github.com/python-distro/distro/pull/269)]
+* Added `__version__` for checking `distro` version [[#292](https://github.com/python-distro/distro/pull/292)]
+* Added support for arbitrary rootfs via the `root_dir` parameter [[#247](https://github.com/python-distro/distro/pull/247)]
+* Added the `--root-dir` option to CLI [[#161](https://github.com/python-distro/distro/issues/161)]
+* Added fallback to `/usr/lib/os-release` when `/etc/os-release` isn't available [[#262](https://github.com/python-distro/distro/pull/262)]
+
+BUG FIXES:
+* Fixed `subprocess.CalledProcessError` when running `lsb_release` [[#261](https://github.com/python-distro/distro/pull/261)]
+* Ignore `/etc/iredmail-release` file while parsing distribution [[#268](https://github.com/python-distro/distro/pull/268)]
+* Use a binary file for `/dev/null` to avoid `TextIOWrapper` overhead [[#271](https://github.com/python-distro/distro/pull/271)]
+
+RELEASE:
+* Moved repository from `nir0s/distro` to
+  [`python-distro/distro`](https://github.com/python-distro/distro) on GitHub.
+
+TESTS:
+* Changed CI to use GitHub Actions [[#277](https://github.com/python-distro/distro/pull/277)]
+
+DOCS:
+* Pinned intersphinx links to Python 3.7 [[#297](https://github.com/python-distro/distro/pull/297)]
+
+
 ## 1.5.0 (2020.3.30)
 
 BACKWARD COMPATIBILITY:

--- a/distro.py
+++ b/distro.py
@@ -37,7 +37,7 @@ import subprocess
 import sys
 import warnings
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"
 
 # Use `if False` to avoid an ImportError on Python 2. After dropping Python 2
 # support, can use typing.TYPE_CHECKING instead. See:


### PR DESCRIPTION
Created a changelog with I believe everything that's landed since last release.
[You can take a peek if I missed anything](https://github.com/python-distro/distro/compare/v1.5.0...master). Put the release date on 2021-07-14 to give time to review but if we need to update the date we can on release day.

Once we merge this I'll create a tag and start the deployment which will also require an approval from someone on the team :)