### PR TITLE
Simplify tox and GitHub actions configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   lint:
-    name: lint
+    name: Lint
     runs-on: ubuntu-latest
 
     steps:
@@ -22,28 +22,20 @@ jobs:
         run: tox -e lint
 
   test:
-    name: ${{ matrix.toxenv }}
+    name: Python ${{ matrix.python }}
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        include:
-          - python: 2.7
-            toxenv: py27
-          - python: 3.5
-            toxenv: py35
-          - python: 3.6
-            toxenv: py36
-          - python: 3.7
-            toxenv: py37
-          - python: 3.8
-            toxenv: py38
-          - python: 3.9
-            toxenv: py39
-          - python: pypy2
-            toxenv: pypy2
-          - python: pypy3
-            toxenv: pypy3
+        python:
+          - 2.7
+          - 3.5
+          - 3.6
+          - 3.7
+          - 3.8
+          - 3.9
+          - pypy2
+          - pypy3
 
     steps:
       - uses: actions/checkout@v2
@@ -82,4 +74,4 @@ jobs:
         run: python -m pip install tox
 
       - name: Run tox
-        run: tox -e pywin
+        run: tox -e py

--- a/tox.ini
+++ b/tox.ini
@@ -13,23 +13,15 @@
 # limitations under the License.
 
 [tox]
-minversion = 1.7.2
+minversion = 1.9
 envlist = lint, py27, py3{4,5,6,7,8,9}, pypy{2,3}
 skip_missing_interpreters = true
 
 [testenv]
 deps =
-    -rdev-requirements.txt
-    codecov
-passenv = CI TRAVIS TRAVIS_*
-commands = pytest --cov-report term-missing --cov distro tests -v
-
-[testenv:pywin]
-deps =
-    -rdev-requirements.txt
-commands= pytest --cov-report term-missing --cov distro tests -v
-basepython = {env:PYTHON:}\python.exe
-passenv= ProgramFiles LOGNAME USER LNAME USERNAME HOME USERPROFILE
+    pytest
+    pytest-cov
+commands = pytest --cov-report term-missing --cov distro
 
 [testenv:lint]
 deps = pre-commit


### PR DESCRIPTION
Unify the default testenv and pywin. These two environments don't
require any differences. The previously passed environment variables go
unused.

Only install a minimal set of dependencies required to run the tox
environments. This helps them run a tiny bit faster.

Bump minversion to 1.9 due to using the skip_install configuration
option.

Drop the GitHub actions "toxenv" matrix variable. As tox command is
executed with "-e py", tox will use the default Python which is already
controlled by GHA.

Rename GHA lint to Lint for consistent capitalization.