### PR TITLE
Fix crash when `uname -rs` output is empty

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -1182,11 +1182,15 @@ class LinuxDistribution(object):
         # type: () -> Dict[str, str]
         with open(os.devnull, "wb") as devnull:
             try:
-                cmd = ("uname", "-rs")
-                stdout = subprocess.check_output(cmd, stderr=devnull)
+                stdout = subprocess.check_output(("uname", "-rs"), stderr=devnull)
             except OSError:
                 return {}
+
         content = self._to_str(stdout).splitlines()
+        if not content:
+            # For some reasons, `uname -rs` output is empty: ignore it.
+            return {}
+
         return self._parse_uname_content(content)
 
     @staticmethod

--- a/distro.py
+++ b/distro.py
@@ -1123,7 +1123,8 @@ class LinuxDistribution:
     @cached_property
     def _uname_info(self) -> Dict[str, str]:
         try:
-            stdout = subprocess.check_output(("uname", "-rs"), stderr=devnull)
+            cmd = ("uname", "-rs")
+            stdout = subprocess.check_output(cmd, stderr=subprocess.DEVNULL)
         except OSError:
             return {}
         content = self._to_str(stdout).splitlines()

--- a/distro.py
+++ b/distro.py
@@ -1185,17 +1185,14 @@ class LinuxDistribution(object):
                 stdout = subprocess.check_output(("uname", "-rs"), stderr=devnull)
             except OSError:
                 return {}
-
         content = self._to_str(stdout).splitlines()
-        if not content:
-            # For some reasons, `uname -rs` output is empty: ignore it.
-            return {}
-
         return self._parse_uname_content(content)
 
     @staticmethod
     def _parse_uname_content(lines):
         # type: (Sequence[str]) -> Dict[str, str]
+        if not lines:
+            return {}
         props = {}
         match = re.search(r"^([^\s]+)\s+([\d\.]+)", lines[0].strip())
         if match:

--- a/tests/resources/testdistros/distro/emptyuname/bin/uname
+++ b/tests/resources/testdistros/distro/emptyuname/bin/uname
@@ -1,3 +1,3 @@
-  #!/bin/sh
+#!/bin/sh
 
 echo -n

--- a/tests/resources/testdistros/distro/emptyuname/bin/uname
+++ b/tests/resources/testdistros/distro/emptyuname/bin/uname
@@ -1,2 +1,3 @@
-#!/bin/sh
+  #!/bin/sh
+
 echo -n

--- a/tests/resources/testdistros/distro/emptyuname/bin/uname
+++ b/tests/resources/testdistros/distro/emptyuname/bin/uname
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo -n

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -712,6 +712,14 @@ class TestSpecialRelease(DistroTestCase):
         assert self.distro.uname_attr("name") == ""
         assert self.distro.uname_attr("release") == ""
 
+    def test_empty_uname(self):
+        self._setup_for_distro(os.path.join(TESTDISTROS, "distro", "emptyuname"))
+        self.distro = distro.LinuxDistribution()
+
+        assert self.distro.uname_attr("id") == ""
+        assert self.distro.uname_attr("name") == ""
+        assert self.distro.uname_attr("release") == ""
+
     def test_usrlibosreleaseonly(self):
         self._setup_for_distro(
             os.path.join(TESTDISTROS, "distro", "usrlibosreleaseonly")


### PR DESCRIPTION
> closes #264

---

**EDIT** : I can backport this patch to the `python2.7-support` branch if you're OK with that.