### PR TITLE
Fix ignored `include_uname` parameter

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -1180,6 +1180,8 @@ class LinuxDistribution(object):
     @cached_property
     def _uname_info(self):
         # type: () -> Dict[str, str]
+        if not self.include_uname:
+            return {}
         with open(os.devnull, "wb") as devnull:
             try:
                 cmd = ("uname", "-rs")

--- a/tests/resources/testdistros/distro/dontincludeuname/bin/uname
+++ b/tests/resources/testdistros/distro/dontincludeuname/bin/uname
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "NetBSD 7.1.1"

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -686,6 +686,15 @@ class TestSpecialRelease(DistroTestCase):
         desired_outcome = {"id": "empty"}
         self._test_outcome(desired_outcome)
 
+    def test_dontincludeuname(self):
+        self._setup_for_distro(os.path.join(TESTDISTROS, "distro", "dontincludeuname"))
+
+        self.distro = distro.LinuxDistribution(include_uname=False)
+
+        assert self.distro.uname_attr("id") == ""
+        assert self.distro.uname_attr("name") == ""
+        assert self.distro.uname_attr("release") == ""
+
     def test_unknowndistro_release(self):
         self._setup_for_distro(os.path.join(TESTDISTROS, "distro", "unknowndistro"))
 


### PR DESCRIPTION
While working on #264 (leading to #304), I noticed that the `include_uname` parameter is completely being ignored by the code base.
This PR addresses this issue and propose a new test to prevent future regression.

Bye 👋

---

**EDIT** : [A quick GitHub search](https://github.com/search?q=include_uname+-filename%3Adistro.py+language%3APython&type=Code) shows that "no one" (at least on this forge) actually uses this flag.

---

**EDIT 2** : I can backport this patch to the `python2.7-support` branch if you're OK with that.

Closes https://github.com/python-distro/distro/issues/309
