### PR TITLE
Added GUIX id

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -216,6 +216,7 @@ def id() -> str:
     "netbsd"        NetBSD
     "freebsd"       FreeBSD
     "midnightbsd"   MidnightBSD
+    "guix"          GNU GUIX System
     ==============  =========================================
 
     If you have a need to get distros for reliable IDs added into this set,


### PR DESCRIPTION
Added a reference for GUIX GNU System, no code changes where needed. The output looks like this:

```json
{
    "codename": "",
    "id": "guix",
    "like": "",
    "version": "5.11.15-gnu",
    "version_parts": {
        "build_number": "15",
        "major": "5",
        "minor": "11"
    }
}
```

Let me know if you need anything else. 