### PR TITLE
Add shebang to distro.py

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Copyright 2015,2016,2017 Nir Cohen
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This allows executing the file as a standalone script.

Previously, without the shebang, trying to execute results in the
following:

    $ ./distro.py
    ./distro.py: line 28: platform.linux_distribution: command not found
    ./distro.py: line 28: platform.dist: command not found
    ./distro.py: line 28: Python: command not found
    ./distro.py: command substitution: line 29: syntax error near unexpected token `newline'
    ./distro.py: command substitution: line 29: `<https://bugs.python.org/issue1322>'
    ...

Now:

    $ ./distro.py
    Name: Fedora 34 (Workstation Edition)
    Version: 34
    Codename: