### PR TITLE
Add Buildroot

### DIFF
--- a/src/distro/distro.py
+++ b/src/distro/distro.py
@@ -220,6 +220,7 @@ def id() -> str:
     "opensuse"      openSUSE
     "amzn"          Amazon Linux
     "arch"          Arch Linux
+    "buildroot"     Buildroot
     "cloudlinux"    CloudLinux OS
     "exherbo"       Exherbo Linux
     "gentoo"        GenToo Linux

--- a/tests/resources/distros/buildroot/etc/os-release
+++ b/tests/resources/distros/buildroot/etc/os-release
@@ -1,0 +1,5 @@
+NAME=Buildroot
+VERSION=2022.02
+ID=buildroot
+VERSION_ID=2022.02
+PRETTY_NAME="Buildroot 2022.02"

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -163,6 +163,17 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
+    def test_buildroot_os_release(self) -> None:
+        desired_outcome = {
+            "id": "buildroot",
+            "name": "Buildroot",
+            "pretty_name": "Buildroot 2022.02",
+            "version": "2022.02",
+            "pretty_version": "2022.02",
+            "best_version": "2022.02",
+        }
+        self._test_outcome(desired_outcome)
+
     def test_kali_os_release(self) -> None:
         desired_outcome = {
             "id": "kali",


### PR DESCRIPTION
This pull request adds Buildroot Linux in distro.id() documentation list and a test.
See: https://buildroot.org/