### PR TITLE
Add Guix System

### DIFF
--- a/src/distro/distro.py
+++ b/src/distro/distro.py
@@ -242,6 +242,7 @@ def id() -> str:
     "midnightbsd"   MidnightBSD
     "rocky"         Rocky Linux
     "aix"           AIX
+    "guix"          Guix System
     ==============  =========================================
 
     If you have a need to get distros for reliable IDs added into this set,

--- a/tests/resources/distros/guix/etc/os-release
+++ b/tests/resources/distros/guix/etc/os-release
@@ -1,0 +1,8 @@
+NAME="Guix System"
+ID=guix
+PRETTY_NAME="Guix System"
+LOGO=guix-icon
+HOME_URL="https://guix.gnu.org"
+DOCUMENTATION_URL="https://guix.gnu.org/en/manual"
+SUPPORT_URL="https://guix.gnu.org/en/help"
+BUG_REPORT_URL="https://lists.gnu.org/mailman/listinfo/bug-guix"

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -262,6 +262,14 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
+    def test_guix_os_release(self) -> None:
+        desired_outcome = {
+            "id": "guix",
+            "name": "Guix System",
+            "pretty_name": "Guix System",
+        }
+        self._test_outcome(desired_outcome)
+
     def test_kvmibm1_os_release(self) -> None:
         desired_outcome = {
             "id": "kvmibm",


### PR DESCRIPTION
Dear maintainers :pray: 

` os-release` file has been copied from : <https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/system.scm?id=245602604455ad9f48571af1fc9ecd6493f6e290#n855>

Closes #303.
Also see #308.

---

CI is currently failing due to an issue with Black and the `click` dependency (not related to this PR), see #331.

Thanks bye :wave: