### PR TITLE
Drop support for end-of-life Python 3.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,12 +28,11 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
-          - "pypy-3.6"
+          - "pypy-3.7"
 
     steps:
       - uses: actions/checkout@v3

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,11 +19,11 @@ If you want to jump into the API description right away, read about the
 Compatibility
 =============
 
-The ``distro`` package is supported on Python 3.6+ and PyPy, and on any Linux
+The ``distro`` package is supported on Python 3.7+ and PyPy, and on any Linux
 or BSD distribution that provides one or more of the `data sources`_ used by
 this package.
 
-This package is tested on Python 3.6+ and PyPy, with test data that mimics the
+This package is tested on Python 3.7+ and PyPy, with test data that mimics the
 exact behavior of the data sources of `a number of Linux distributions
 <https://github.com/python-distro/distro/tree/master/tests/resources/distros>`_.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     Operating System :: POSIX :: BSD :: OpenBSD
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -33,7 +32,7 @@ classifiers =
 package_dir =
     = src
 packages = distro
-python_requires = >=3.6
+python_requires = >=3.7
 
 [options.package_data]
 * = py.typed

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@
 
 [tox]
 minversion = 1.9
-envlist = lint, py{36,37,38,39,310,py3}
+envlist = lint, py{37,38,39,310,py3}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
https://endoflife.date/python