### PR TITLE
Improve readme 'usage' code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ $ python
 >>> import distro
 >>> distro.name(pretty=True)
 'CentOS Linux 8'
+>>> distro.id()
+'centos'
 >>> distro.version(best=True)
 '8.4.2105'
 ```

--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ $ distro -j
 
 $ python
 >>> import distro
->>> distro.linux_distribution(full_distribution_name=False)
-('centos', '7.1.1503', 'Core')
+>>> distro.name(pretty=True)
+'CentOS Linux 8'
+>>> distro.version(best=True)
+'8.4.2105'
 ```
 
 


### PR DESCRIPTION
Remove `distro.linux_distribution()` since it has been depreciated in the 'Usage' code block and replace it with `distro.name()` and `distro.version()` examples.

Thanks a lot to the creator, maintainers and everyone involved with the project, this library is incredibly useful