### PR TITLE
Cache `/etc/debian_version` content

### DIFF
--- a/src/distro/distro.py
+++ b/src/distro/distro.py
@@ -900,13 +900,7 @@ class LinuxDistribution:
             versions.insert(0, self.oslevel_info())
         elif self.id() == "debian" or "debian" in self.like().split():
             # On Debian-like, add debian_version file content to candidates list.
-            try:
-                with open(
-                    os.path.join(self.etc_dir, "debian_version"), encoding="ascii"
-                ) as fp:
-                    versions.append(fp.readline().rstrip())
-            except FileNotFoundError:
-                pass
+            versions.append(self._debian_version)
         version = ""
         if best:
             # This algorithm uses the last version in priority order that has
@@ -1216,6 +1210,16 @@ class LinuxDistribution:
         except (OSError, subprocess.CalledProcessError):
             return ""
         return self._to_str(stdout).strip()
+
+    @cached_property
+    def _debian_version(self) -> str:
+        try:
+            with open(
+                os.path.join(self.etc_dir, "debian_version"), encoding="ascii"
+            ) as fp:
+                return fp.readline().rstrip()
+        except FileNotFoundError:
+            return ""
 
     @staticmethod
     def _parse_uname_content(lines: Sequence[str]) -> Dict[str, str]:

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -2272,6 +2272,6 @@ class TestRepr:
         repr_str = repr(distro._distro)
         assert "LinuxDistribution" in repr_str
         for attr in MODULE_DISTRO.__dict__.keys():
-            if attr in ("root_dir", "etc_dir", "usr_lib_dir"):
+            if attr in ("root_dir", "etc_dir", "usr_lib_dir", "_debian_version"):
                 continue
             assert f"{attr}=" in repr_str


### PR DESCRIPTION
This patch is a follow-up for 6d44662 (#333), introducing caching of `/etc/debian_version` file content, to prevent opening and reading operations for each `distro.version()` call.

---

@python-distro/maintainers : we can release a new version once this PR is merged 🙂 