### PR TITLE
Add Debian Testing to the tests

### DIFF
--- a/tests/resources/distros/debiantesting/bin/lsb_release
+++ b/tests/resources/distros/debiantesting/bin/lsb_release
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# lsb_release command for testing the ld module.
+# Only the -a option is supported.
+#
+# This version of the lsb_release command works without a corresponding
+# etc/lsb-release file.
+#
+
+if [[ "$@" != "-a" ]]; then
+  echo "Usage: lsb_release -a"
+  exit 2
+fi
+
+cat <<OUT
+No LSB modules are available.
+Distributor ID:	Debian
+Description:	Debian GNU/Linux bookworm/sid
+Release:	n/a
+Codename:	bookworm
+OUT
+
+exit 0

--- a/tests/resources/distros/debiantesting/etc/debian_version
+++ b/tests/resources/distros/debiantesting/etc/debian_version
@@ -1,0 +1,1 @@
+bookworm/sid

--- a/tests/resources/distros/debiantesting/etc/os-release
+++ b/tests/resources/distros/debiantesting/etc/os-release
@@ -1,0 +1,7 @@
+PRETTY_NAME="Debian GNU/Linux bookworm/sid"
+NAME="Debian GNU/Linux"
+VERSION_CODENAME=bookworm
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -233,6 +233,18 @@ class TestOSRelease:
         }
         self._test_outcome(desired_outcome)
 
+    def test_debiantesting_os_release(self) -> None:
+        desired_outcome = {
+            "id": "debian",
+            "name": "Debian GNU/Linux",
+            "pretty_name": "Debian GNU/Linux bookworm/sid",
+            "version": "bookworm/sid",
+            "pretty_version": "bookworm/sid (bookworm)",
+            "best_version": "bookworm/sid",
+            "codename": "bookworm",
+        }
+        self._test_outcome(desired_outcome)
+
     def test_fedora19_os_release(self) -> None:
         desired_outcome = {
             "id": "fedora",
@@ -1251,6 +1263,20 @@ class TestOverall(DistroTestCase):
             "best_version": "10.11",
             "codename": "buster",
             "major_version": "10",
+        }
+        self._test_outcome(desired_outcome)
+        self._test_non_existing_release_file()
+
+    def test_debiantesting_release(self) -> None:
+        desired_outcome = {
+            "id": "debian",
+            "name": "Debian GNU/Linux",
+            "pretty_name": "Debian GNU/Linux bookworm/sid",
+            "version": "bookworm/sid",
+            "pretty_version": "bookworm/sid (bookworm)",
+            "best_version": "bookworm/sid",
+            "codename": "bookworm",
+            "major_version": "",
         }
         self._test_outcome(desired_outcome)
         self._test_non_existing_release_file()


### PR DESCRIPTION
Debian Testing's version metadata is a different format to the Debian Release version metadata. I hope having this in your test suite will be helpful.

I found that function `version()` in v1.6.0 of `distro` was returning:
```
(Pdb) p versions
['', 'n/a', '', '', '', '']
```
in https://github.com/spack/spack/ v0.19.1. Spack was then taking the first element of "n/a" (i.e. "n") and using it at as the version!