### PR TITLE
Ignore the file '/etc/ec2_version'

### DIFF
--- a/src/distro/distro.py
+++ b/src/distro/distro.py
@@ -153,6 +153,7 @@ _DISTRO_RELEASE_IGNORE_BASENAMES = (
     "plesk-release",
     "iredmail-release",
     "board-release",
+    "ec2_version",
 )
 
 


### PR DESCRIPTION
Dear Sebastian, dear maintainers,

Closes https://github.com/python-distro/distro/issues/358

It was observed that on ubuntu22.04.2 instances created on GCP and Azure with python installed, distro.version() returned incorrect version due to incorrect version present in  /etc/ec2_version file.

This pull request contains a small change to add /etc/ec2_version as part of _DISTRO_RELEASE_IGNORE_BASENAMES, so that it wont be used as data source.

Thank you.