### PR TITLE
Refactor `distro.info()` method to return an `InfoDict`

### DIFF
--- a/src/distro/distro.py
+++ b/src/distro/distro.py
@@ -995,10 +995,10 @@ class LinuxDistribution:
 
         For details, see :func:`distro.info`.
         """
-        return dict(
+        return InfoDict(
             id=self.id(),
             version=self.version(pretty, best),
-            version_parts=dict(
+            version_parts=VersionDict(
                 major=self.major_version(best),
                 minor=self.minor_version(best),
                 build_number=self.build_number(best),


### PR DESCRIPTION
This commit modifies the `distro.info()` method in the `distro.py` file. The method now returns an `InfoDict` object instead of a regular dictionary. This change improves the consistency and readability of the codebase. The `InfoDict` object contains the distribution ID, version, and version parts. The change does not affect the functionality of the method.