### PR TITLE
Deprecates `uname_attr` and `uname_info` public methods

### DIFF
--- a/src/distro/distro.py
+++ b/src/distro/distro.py
@@ -546,9 +546,19 @@ def distro_release_info() -> Dict[str, str]:
 
 def uname_info() -> Dict[str, str]:
     """
+    .. deprecated:: 1.11.0
+
+        :func:`distro.uname_info()` is deprecated and will be removed in a
+        future version.
+
     Return a dictionary containing key-value pairs for the information items
     from the distro release file data source of the current OS distribution.
     """
+    warnings.warn(
+        "distro.uname_info() is deprecated and will be removed in a future version.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return _distro.uname_info()
 
 
@@ -612,6 +622,11 @@ def distro_release_attr(attribute: str) -> str:
 
 def uname_attr(attribute: str) -> str:
     """
+    .. deprecated:: 1.11.0
+
+        :func:`distro.uname_attr()` is deprecated and will be removed in a
+        future version.
+
     Return a single named information item from the distro release file
     data source of the current OS distribution.
 
@@ -624,6 +639,11 @@ def uname_attr(attribute: str) -> str:
     * (string): Value of the information item, if the item exists.
                 The empty string, if the item does not exist.
     """
+    warnings.warn(
+        "distro.uname_attr() is deprecated and will be removed in a future version.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return _distro.uname_attr(attribute)
 
 
@@ -853,7 +873,7 @@ class LinuxDistribution:
         if distro_id:
             return normalize(distro_id, NORMALIZED_DISTRO_ID)
 
-        distro_id = self.uname_attr("id")
+        distro_id = self._uname_attr("id")
         if distro_id:
             return normalize(distro_id, NORMALIZED_DISTRO_ID)
 
@@ -869,14 +889,14 @@ class LinuxDistribution:
             self.os_release_attr("name")
             or self.lsb_release_attr("distributor_id")
             or self.distro_release_attr("name")
-            or self.uname_attr("name")
+            or self._uname_attr("name")
         )
         if pretty:
             name = self.os_release_attr("pretty_name") or self.lsb_release_attr(
                 "description"
             )
             if not name:
-                name = self.distro_release_attr("name") or self.uname_attr("name")
+                name = self.distro_release_attr("name") or self._uname_attr("name")
                 version = self.version(pretty=True)
                 if version:
                     name = f"{name} {version}"
@@ -898,9 +918,9 @@ class LinuxDistribution:
             self._parse_distro_release_content(
                 self.lsb_release_attr("description")
             ).get("version_id", ""),
-            self.uname_attr("release"),
+            self._uname_attr("release"),
         ]
-        if self.uname_attr("id").startswith("aix"):
+        if self._uname_attr("id").startswith("aix"):
             # On AIX platforms, prefer oslevel command output.
             versions.insert(0, self.oslevel_info())
         elif self.id() == "debian" or "debian" in self.like().split():
@@ -1042,11 +1062,24 @@ class LinuxDistribution:
 
     def uname_info(self) -> Dict[str, str]:
         """
+        .. deprecated:: 1.11.0
+
+            :func:`LinuxDistribution.uname_info()` is deprecated and will be removed
+            in a future version.
+
         Return a dictionary containing key-value pairs for the information
         items from the uname command data source of the OS distribution.
 
         For details, see :func:`distro.uname_info`.
         """
+        warnings.warn(
+            (
+                "LinuxDistribution.uname_info() is deprecated and will be removed in a"
+                " future version."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._uname_info
 
     def oslevel_info(self) -> str:
@@ -1083,6 +1116,28 @@ class LinuxDistribution:
         return self._distro_release_info.get(attribute, "")
 
     def uname_attr(self, attribute: str) -> str:
+        """
+        .. deprecated:: 1.11.0
+
+            :func:`LinuxDistribution.uname_attr()` is deprecated and will be removed in
+            a future version.
+
+        Return a single named information item from the uname command
+        output data source of the OS distribution.
+
+        For details, see :func:`distro.uname_attr`.
+        """
+        warnings.warn(
+            (
+                "LinuxDistribution.uname_attr() is deprecated and will be removed in a"
+                " future version."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._uname_attr(attribute)
+
+    def _uname_attr(self, attribute: str) -> str:
         """
         Return a single named information item from the uname command
         output data source of the OS distribution.

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -779,9 +779,9 @@ class TestSpecialRelease(DistroTestCase):
 
         self.distro = distro.LinuxDistribution(include_uname=False)
 
-        assert self.distro.uname_attr("id") == ""
-        assert self.distro.uname_attr("name") == ""
-        assert self.distro.uname_attr("release") == ""
+        assert self.distro._uname_attr("id") == ""
+        assert self.distro._uname_attr("name") == ""
+        assert self.distro._uname_attr("release") == ""
 
     def test_unknowndistro_release(self) -> None:
         self._setup_for_distro(os.path.join(TESTDISTROS, "distro", "unknowndistro"))
@@ -805,17 +805,17 @@ class TestSpecialRelease(DistroTestCase):
         self._setup_for_distro(os.path.join(TESTDISTROS, "distro", "baduname"))
         self.distro = distro.LinuxDistribution()
 
-        assert self.distro.uname_attr("id") == ""
-        assert self.distro.uname_attr("name") == ""
-        assert self.distro.uname_attr("release") == ""
+        assert self.distro._uname_attr("id") == ""
+        assert self.distro._uname_attr("name") == ""
+        assert self.distro._uname_attr("release") == ""
 
     def test_empty_uname(self) -> None:
         self._setup_for_distro(os.path.join(TESTDISTROS, "distro", "emptyuname"))
         self.distro = distro.LinuxDistribution()
 
-        assert self.distro.uname_attr("id") == ""
-        assert self.distro.uname_attr("name") == ""
-        assert self.distro.uname_attr("release") == ""
+        assert self.distro._uname_attr("id") == ""
+        assert self.distro._uname_attr("name") == ""
+        assert self.distro._uname_attr("release") == ""
 
     def test_usrlibosreleaseonly(self) -> None:
         self._setup_for_distro(


### PR DESCRIPTION
(see #322 for context)

distro as well as LinuxDistribution `uname_attr` and `uname_info` public methods are based on `_parse_uname_content` function which purposely ignores release information part from `uname -rs` command output on Linux platforms. This makes it specially designed for distro internals, and shouldn't be publicly available as stable API.

We'll deprecate these methods in v1.11.0, in order to allow API removals in the future (e.g. distro v2).