### PR TITLE
Handle `CalledProcessError` when calling `uname`

### DIFF
--- a/src/distro/distro.py
+++ b/src/distro/distro.py
@@ -1204,7 +1204,7 @@ class LinuxDistribution:
         try:
             cmd = ("uname", "-rs")
             stdout = subprocess.check_output(cmd, stderr=subprocess.DEVNULL)
-        except OSError:
+        except (OSError, subprocess.CalledProcessError):
             return {}
         content = self._to_str(stdout).splitlines()
         return self._parse_uname_content(content)


### PR DESCRIPTION
Usually, when `distro` is used in Windows, it returns nothing. Any call to `lsb_release`, `uname`, etc, raises a `[[WinError 2] The system cannot find the file specified` error, which is properly handled. However, in a particular environment where I've run it, I've found that the call to `uname` raises a `CalledProcessError`, because a Policy or a Security Control is injecting a non-zero return code:

```
t=2024-10-04T15:13:39+0200  Command '('uname', '-rs')' returned non-zero exit status 3221225794.
Traceback (most recent call last):
  File "C:\...\main.py", line 123, in __check_supported_platform
    distro_id = distro.id()
                ^^^^^^^^^^^
  File "C:\...\site-packages\distro\distro.py", line 284, in id
    return _distro.id()
           ^^^^^^^^^^^^
  File "C:\...\site-packages\distro\distro.py", line 855, in id
    distro_id = self.uname_attr("id")
                ^^^^^^^^^^^^^^^^^^^^^
  File "C:\...\site-packages\distro\distro.py", line 1088, in uname_attr
    return self._uname_info.get(attribute, "")
           ^^^^^^^^^^^^^^^^
  File "C:\...\lib\functools.py", line 995, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File "C:\...\site-packages\distro\distro.py", line 1202, in _uname_info
    stdout = subprocess.check_output(cmd, stderr=subprocess.DEVNULL)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\...\lib\subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\...\lib\subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '('uname', '-rs')' returned non-zero exit status 3221225794.
```

We do handle `CalledProcessError` in other calls, so I'm adding it to `uname` too.