### PR TITLE
Ignore "n/a" from `lsb_release` output allowing other sources to be honored

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ namely from these data sources (from high to low precedence):
 * The os-release file `/etc/os-release` if present, with a fall-back on `/usr/lib/os-release` if needed.
 * The output of the `lsb_release` command, if available.
 * The distro release file (`/etc/*(-|_)(release|version)`), if present.
-* The `uname` command for BSD based distrubtions.
+* The `uname` command for BSD based distributions.
 
 
 ## Python and Distribution Support

--- a/src/distro/distro.py
+++ b/src/distro/distro.py
@@ -1193,8 +1193,10 @@ class LinuxDistribution:
             if len(kv) != 2:
                 # Ignore lines without colon.
                 continue
-            k, v = kv
-            props.update({k.replace(" ", "_").lower(): v.strip()})
+            k, v = kv[0], kv[1].strip()
+            if v == "n/a":
+                v = ""
+            props.update({k.replace(" ", "_").lower(): v})
         return props
 
     @cached_property

--- a/tests/resources/testdistros/lsb/debian13_noosrelease/bin/lsb_release
+++ b/tests/resources/testdistros/lsb/debian13_noosrelease/bin/lsb_release
@@ -1,0 +1,8 @@
+#!/bin/bash
+/bin/cat <<'EOT'
+No LSB modules are available.
+Distributor ID:	Debian
+Description:	Debian GNU/Linux trixie/sid
+Release:	n/a
+Codename:	trixie
+EOT

--- a/tests/resources/testdistros/lsb/debian13_noosrelease/etc/debian_version
+++ b/tests/resources/testdistros/lsb/debian13_noosrelease/etc/debian_version
@@ -1,0 +1,1 @@
+trixie/sid

--- a/tests/test_distro.py
+++ b/tests/test_distro.py
@@ -695,6 +695,25 @@ class TestLSBRelease(DistroTestCase):
         }
         self._test_outcome(desired_outcome)
 
+    def test_debian13noosrelease_lsb_release(self) -> None:
+        self._setup_for_distro(os.path.join(TESTDISTROS, "lsb", "debian13_noosrelease"))
+
+        self.distro = distro.LinuxDistribution(
+            os_release_file="path-to-non-existing-file",
+            distro_release_file="path-to-non-existing-file",
+        )
+
+        desired_outcome = {
+            "id": "debian",
+            "name": "Debian",
+            "pretty_name": "Debian GNU/Linux trixie/sid",
+            "version": "trixie/sid",
+            "pretty_version": "trixie/sid (trixie)",
+            "best_version": "trixie/sid",
+            "codename": "trixie",
+        }
+        self._test_outcome(desired_outcome)
+
     def test_ubuntu14nomodules_lsb_release(self) -> None:
         self._setup_for_distro(os.path.join(TESTDISTROS, "lsb", "ubuntu14_nomodules"))
 
@@ -1677,9 +1696,9 @@ class TestOverall(DistroTestCase):
             "name": "SLES",
             "pretty_name": "SUSE Linux Enterprise Server 12 SP1",
             "version": "12.1",
-            "pretty_version": "12.1 (n/a)",
+            "pretty_version": "12.1 (s390x)",
             "best_version": "12.1",
-            "codename": "n/a",
+            "codename": "s390x",
             "major_version": "12",
             "minor_version": "1",
         }


### PR DESCRIPTION
> closes #373